### PR TITLE
/refund

### DIFF
--- a/crates/x402-axum/src/facilitator_client.rs
+++ b/crates/x402-axum/src/facilitator_client.rs
@@ -134,6 +134,16 @@ impl Facilitator for FacilitatorClient {
         )
         .await
     }
+
+    /// Attempts to refund a verified payment with the facilitator.
+    /// Instruments a tracing span (only when telemetry feature is enabled).
+    #[cfg(not(feature = "telemetry"))]
+    async fn refund(
+        &self,
+        request: &RefundRequest,
+    ) -> Result<RefundResponse, FacilitatorClientError> {
+        FacilitatorClient::refund(self, request).await
+    }
 }
 
 /// Errors that can occur while interacting with a remote facilitator.
@@ -204,7 +214,7 @@ impl FacilitatorClient {
 
     /// Constructs a new [`FacilitatorClient`] from a base URL.
     ///
-    /// This sets up `./verify` and `./settle` endpoint URLs relative to the base.
+    /// This sets up `./verify`, `./settle` and `./refund` endpoint URLs relative to the base.
     pub fn try_new(base_url: Url) -> Result<Self, FacilitatorClientError> {
         let client = Client::new();
         let verify_url =

--- a/crates/x402-axum/src/facilitator_client.rs
+++ b/crates/x402-axum/src/facilitator_client.rs
@@ -35,7 +35,8 @@ use std::time::Duration;
 use url::Url;
 use x402_rs::facilitator::Facilitator;
 use x402_rs::types::{
-    SettleRequest, SettleResponse, SupportedPaymentKindsResponse, VerifyRequest, VerifyResponse,
+    RefundRequest, RefundResponse, SettleRequest, SettleResponse, SupportedPaymentKindsResponse,
+    VerifyRequest, VerifyResponse,
 };
 
 #[cfg(feature = "telemetry")]
@@ -53,6 +54,8 @@ pub struct FacilitatorClient {
     verify_url: Url,
     /// Full URL to `POST /settle` requests
     settle_url: Url,
+    /// Full URL to `POST /refund` requests
+    refund_url: Url,
     /// Full URL to `GET /supported` requests
     supported_url: Url,
     /// Shared Reqwest HTTP client
@@ -116,6 +119,20 @@ impl Facilitator for FacilitatorClient {
         request: &SettleRequest,
     ) -> Result<SettleResponse, FacilitatorClientError> {
         FacilitatorClient::settle(self, request).await
+    }
+
+    /// Attempts to refund a verified payment with the facilitator.
+    /// Instruments a tracing span (only when telemetry feature is enabled).
+    #[cfg(feature = "telemetry")]
+    async fn refund(
+        &self,
+        request: &RefundRequest,
+    ) -> Result<RefundResponse, FacilitatorClientError> {
+        with_span(
+            FacilitatorClient::refund(self, request),
+            tracing::info_span!("x402.facilitator_client.refund", timeout = ?self.timeout),
+        )
+        .await
     }
 }
 
@@ -204,6 +221,13 @@ impl FacilitatorClient {
                     context: "Failed to construct ./settle URL",
                     source: e,
                 })?;
+        let refund_url =
+            base_url
+                .join("./refund")
+                .map_err(|e| FacilitatorClientError::UrlParse {
+                    context: "Failed to construct ./refund URL",
+                    source: e,
+                })?;
         let supported_url =
             base_url
                 .join("./supported")
@@ -216,6 +240,7 @@ impl FacilitatorClient {
             base_url,
             verify_url,
             settle_url,
+            refund_url,
             supported_url,
             headers: HeaderMap::new(),
             timeout: None,
@@ -253,6 +278,15 @@ impl FacilitatorClient {
         request: &SettleRequest,
     ) -> Result<SettleResponse, FacilitatorClientError> {
         self.post_json(&self.settle_url, "POST /settle", request)
+            .await
+    }
+
+    /// Sends a `POST /refund` request to the facilitator.
+    pub async fn refund(
+        &self,
+        request: &RefundRequest,
+    ) -> Result<RefundResponse, FacilitatorClientError> {
+        self.post_json(&self.refund_url, "POST /refund", request)
             .await
     }
 

--- a/src/chain/evm.rs
+++ b/src/chain/evm.rs
@@ -17,7 +17,7 @@
 use alloy::contract::SolCallBuilder;
 use alloy::dyn_abi::SolType;
 use alloy::network::{EthereumWallet, TransactionBuilder};
-use alloy::primitives::{Bytes, FixedBytes, U256, address};
+use alloy::primitives::{Address, Bytes, FixedBytes, U256, address};
 use alloy::providers::bindings::IMulticall3;
 use alloy::providers::fillers::{
     BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, WalletFiller,
@@ -37,9 +37,10 @@ use crate::network::{Network, USDCDeployment};
 use crate::timestamp::UnixTimestamp;
 use crate::types::{
     EvmAddress, EvmSignature, ExactPaymentPayload, FacilitatorErrorReason, HexEncodedNonce,
-    MixedAddress, PaymentPayload, PaymentRequirements, Scheme, SettleRequest, SettleResponse,
-    SupportedPaymentKind, SupportedPaymentKindsResponse, TokenAmount, TransactionHash,
-    TransferWithAuthorization, VerifyRequest, VerifyResponse, X402Version,
+    MixedAddress, PaymentPayload, PaymentRequirements, RefundRequest, RefundResponse, Scheme,
+    SettleRequest, SettleResponse, SupportedPaymentKind, SupportedPaymentKindsResponse,
+    TokenAmount, TransactionHash, TransferWithAuthorization, VerifyRequest, VerifyResponse,
+    X402Version,
 };
 
 sol!(
@@ -636,6 +637,62 @@ impl Facilitator for EvmProvider {
                 payer: payment.from.into(),
                 transaction: Some(TransactionHash::Evm(receipt.transaction_hash.0)),
                 network: payload.network,
+            })
+        }
+    }
+
+    async fn refund(&self, request: &RefundRequest) -> Result<RefundResponse, Self::Error> {
+        if request.network != self.network() {
+            return Err(FacilitatorLocalError::NetworkMismatch(
+                None,
+                self.network(),
+                request.network,
+            ));
+        }
+
+        let to: EvmAddress = request
+            .to
+            .clone()
+            .try_into()
+            .map_err(|e| FacilitatorLocalError::InvalidAddress(format!("{e:?}")))?;
+        let token_address: Address = request
+            .asset
+            .clone()
+            .try_into()
+            .map_err(|e| FacilitatorLocalError::InvalidAddress(format!("{e:?}")))?;
+        let amount: U256 = request.amount.into();
+
+        let contract = USDC::new(token_address, &self.inner);
+        let mut call = contract.transfer(to.into, amount);
+        if !self.eip1559 {
+            let gas: u128 = self
+                .inner
+                .get_gas_price()
+                .instrument(tracing::info_span!("get_gas_price"))
+                .await
+                .map_err(|e| FacilitatorLocalError::ContractCall(format!("{e:?}")))?;
+            call = call.gas_price(gas)
+        }
+
+        let tx = call.into_transaction_request();
+        let receipt = self.send_transaction(tx).await?;
+        let success = receipt.status();
+
+        if success {
+            Ok(RefundResponse {
+                success: true,
+                error_reason: None,
+                to: request.to.clone(),
+                transaction: Some(TransactionHash::Evm(receipt.transaction_hash.0)),
+                network: request.network,
+            })
+        } else {
+            Ok(RefundResponse {
+                success: false,
+                error_reason: Some(FacilitatorErrorReason::UnexpectedRefundError),
+                to: request.to.clone(),
+                transaction: Some(TransactionHash::Evm(receipt.transaction_hash.0)),
+                network: request.network,
             })
         }
     }

--- a/src/chain/evm.rs
+++ b/src/chain/evm.rs
@@ -663,7 +663,7 @@ impl Facilitator for EvmProvider {
         let amount: U256 = request.amount.into();
 
         let contract = USDC::new(token_address, &self.inner);
-        let mut call = contract.transfer(to.into, amount);
+        let mut call = contract.transfer(to.into(), amount);
         if !self.eip1559 {
             let gas: u128 = self
                 .inner

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -5,8 +5,8 @@ use crate::chain::solana::SolanaProvider;
 use crate::facilitator::Facilitator;
 use crate::network::Network;
 use crate::types::{
-    MixedAddress, Scheme, SettleRequest, SettleResponse, SupportedPaymentKindsResponse,
-    VerifyRequest, VerifyResponse,
+    MixedAddress, RefundRequest, RefundResponse, Scheme, SettleRequest, SettleResponse,
+    SupportedPaymentKindsResponse, VerifyRequest, VerifyResponse,
 };
 
 pub mod evm;
@@ -53,6 +53,13 @@ impl Facilitator for NetworkProvider {
         match self {
             NetworkProvider::Evm(provider) => provider.settle(request).await,
             NetworkProvider::Solana(provider) => provider.settle(request).await,
+        }
+    }
+
+    async fn refund(&self, request: &RefundRequest) -> Result<RefundResponse, Self::Error> {
+        match self {
+            NetworkProvider::Evm(provider) => provider.refund(request).await,
+            NetworkProvider::Solana(provider) => provider.refund(request).await,
         }
     }
 

--- a/src/chain/solana.rs
+++ b/src/chain/solana.rs
@@ -3,8 +3,9 @@ use crate::facilitator::Facilitator;
 use crate::network::Network;
 use crate::types::{
     Base64Bytes, ExactPaymentPayload, FacilitatorErrorReason, MixedAddress, PaymentRequirements,
-    SettleRequest, SettleResponse, SupportedPaymentKind, SupportedPaymentKindExtra,
-    SupportedPaymentKindsResponse, TokenAmount, TransactionHash, VerifyRequest, VerifyResponse,
+    RefundRequest, RefundResponse, SettleRequest, SettleResponse, SupportedPaymentKind,
+    SupportedPaymentKindExtra, SupportedPaymentKindsResponse, TokenAmount, TransactionHash,
+    VerifyRequest, VerifyResponse,
 };
 use solana_client::rpc_client::RpcClient;
 use solana_client::rpc_config::{RpcSendTransactionConfig, RpcSimulateTransactionConfig};
@@ -505,6 +506,10 @@ impl Facilitator for SolanaProvider {
             network: self.network(),
         };
         Ok(settle_response)
+    }
+
+    async fn refund(&self, _request: &RefundRequest) -> Result<RefundResponse, Self::Error> {
+        Err(FacilitatorLocalError::UnsupportedNetwork(None))
     }
 
     async fn supported(&self) -> Result<SupportedPaymentKindsResponse, Self::Error> {

--- a/src/facilitator.rs
+++ b/src/facilitator.rs
@@ -6,7 +6,8 @@
 use std::fmt::{Debug, Display};
 
 use crate::types::{
-    SettleRequest, SettleResponse, SupportedPaymentKindsResponse, VerifyRequest, VerifyResponse,
+    RefundRequest, RefundResponse, SettleRequest, SettleResponse, SupportedPaymentKindsResponse,
+    VerifyRequest, VerifyResponse,
 };
 
 /// Trait defining the asynchronous interface for x402 payment facilitators.
@@ -51,6 +52,24 @@ pub trait Facilitator {
         &self,
         request: &SettleRequest,
     ) -> impl Future<Output = Result<SettleResponse, Self::Error>> + Send;
+
+    /// Executes an on-chain x402 refund for a valid [`RefundRequest`].
+    ///
+    /// This method should validate the payment and, if valid, perform
+    /// an onchain call to refund the payment to the given address.
+    ///
+    /// # Returns
+    ///
+    /// A [`RefundResponse`] indicating whether the refund was successful, and
+    /// containing any on-chain transaction metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if verification or refund fails.
+    fn refund(
+        &self,
+        request: &RefundRequest,
+    ) -> impl Future<Output = Result<RefundResponse, Self::Error>> + Send;
 
     fn supported(
         &self,

--- a/src/facilitator_local.rs
+++ b/src/facilitator_local.rs
@@ -16,8 +16,9 @@ use crate::facilitator::Facilitator;
 use crate::provider_cache::ProviderCache;
 use crate::provider_cache::ProviderMap;
 use crate::types::{
-    Scheme, SettleRequest, SettleResponse, SupportedPaymentKind, SupportedPaymentKindExtra,
-    SupportedPaymentKindsResponse, VerifyRequest, VerifyResponse, X402Version,
+    RefundRequest, RefundResponse, Scheme, SettleRequest, SettleResponse, SupportedPaymentKind,
+    SupportedPaymentKindExtra, SupportedPaymentKindsResponse, VerifyRequest, VerifyResponse,
+    X402Version,
 };
 
 /// A concrete [`Facilitator`] implementation that verifies and settles x402 payments
@@ -109,6 +110,15 @@ impl Facilitator for FacilitatorLocal {
             .by_network(network)
             .ok_or(FacilitatorLocalError::UnsupportedNetwork(None))?;
         provider.settle(request).await
+    }
+
+    async fn refund(&self, request: &RefundRequest) -> Result<RefundResponse, Self::Error> {
+        let network = request.network;
+        let provider = self
+            .provider_cache
+            .by_network(network)
+            .ok_or(FacilitatorLocalError::UnsupportedNetwork(None))?;
+        provider.refund(request).await
     }
 
     async fn supported(&self) -> Result<SupportedPaymentKindsResponse, Self::Error> {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -19,8 +19,8 @@ use crate::chain::FacilitatorLocalError;
 use crate::facilitator::Facilitator;
 use crate::facilitator_local::FacilitatorLocal;
 use crate::types::{
-    ErrorResponse, FacilitatorErrorReason, MixedAddress, RefundRequest, RefundResponse,
-    SettleRequest, VerifyRequest, VerifyResponse,
+    ErrorResponse, FacilitatorErrorReason, MixedAddress, RefundRequest, SettleRequest,
+    VerifyRequest, VerifyResponse,
 };
 
 /// `GET /verify`: Returns a machine-readable description of the `/verify` endpoint.

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,8 @@ async fn main() {
         .route("/verify", post(handlers::post_verify))
         .route("/settle", get(handlers::get_settle_info))
         .route("/settle", post(handlers::post_settle))
+        .route("/refund", get(handlers::get_refund_info))
+        .route("/refund", post(handlers::post_refund))
         .route("/supported", get(handlers::get_supported))
         .layer(Extension(facilitator))
         .layer(

--- a/src/types.rs
+++ b/src/types.rs
@@ -1061,6 +1061,26 @@ impl<'de> Deserialize<'de> for VerifyResponse {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefundRequest {
+    pub x402_version: X402Version,
+    pub network: Network,
+    pub asset: MixedAddress,
+    pub to: MixedAddress,
+    pub amount: TokenAmount,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefundResponse {
+    pub success: bool,
+    pub error_reason: Option<FacilitatorErrorReason>,
+    pub to: MixedAddress,
+    pub transaction: Option<TransactionHash>,
+    pub network: Network,
+}
+
 /// A simple error structure returned on unexpected or fatal server errors.
 /// Used when no structured protocol-level response is appropriate.
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -921,6 +921,10 @@ pub enum FacilitatorErrorReason {
     #[error("unexpected_settle_error")]
     #[serde(rename = "unexpected_settle_error")]
     UnexpectedSettleError,
+    /// Unexpected refund error
+    #[error("unexpected_refund_error")]
+    #[serde(rename = "unexpected_refund_error")]
+    UnexpectedRefundError,
 }
 
 /// Returned from a facilitator after attempting to settle a payment on-chain.


### PR DESCRIPTION
adds a `/refund` endpoint that the server can call into to do a refund for the unused funds to the client

Questions:
this requires an update to the x402 spec?