### PR TITLE
chore(crates/x402-axum): not settled if reponse bad

### DIFF
--- a/crates/x402-axum/src/layer.rs
+++ b/crates/x402-axum/src/layer.rs
@@ -645,6 +645,9 @@ where
             Ok(response) => response,
             Err(err) => return err.into_response(),
         };
+        if response.status().is_client_error() || response.status().is_server_error() {
+            return response.into_response();
+        }
         let settlement = match self.settle_payment(&verify_request).await {
             Ok(settlement) => settlement,
             Err(err) => return err.into_response(),


### PR DESCRIPTION
x402-axum middleware skips payment settlement if the protected route returns a 4XX or 5XX status code