### PR TITLE
chore(x402-reqwest) solana set dyn priority fee

### DIFF
--- a/crates/x402-reqwest/src/chains/solana.rs
+++ b/crates/x402-reqwest/src/chains/solana.rs
@@ -212,8 +212,9 @@ impl SenderWallet for SolanaSenderWallet {
             .rpc_client
             .get_latest_blockhash()
             .map_err(|e| X402PaymentsError::SigningError(format!("{e:?}")))?;
+        let fee = get_priority_fee_micro_lamports(self.rpc_client.as_ref(), &vec![fee_payer, destination_ata, source_ata])?;
         let (msg_to_sim, instructions) =
-            build_message_to_simulate(fee_payer, &transfer_instructions, 1, recent_blockhash)?;
+            build_message_to_simulate(fee_payer, &transfer_instructions, fee, recent_blockhash)?;
         // 2) Estimate CU via simulation
         let estimated_cu = estimate_compute_units(self.rpc_client.as_ref(), &msg_to_sim)?;
         // prepend the CU limit instruction
@@ -322,6 +323,19 @@ pub fn estimate_compute_units(
             "simulation returned no units_consumed".to_string(),
         ))?;
     Ok(units as u32)
+}
+
+pub fn get_priority_fee_micro_lamports(rpc: &RpcClient, writeable_accounts: &[Pubkey]) -> Result<u64, X402PaymentsError> {    
+    let fee = rpc
+        .get_recent_prioritization_fees(&writeable_accounts)
+        .map_err(|e| X402PaymentsError::SigningError(format!("{e:?}")))?
+        .iter()
+        .filter(|e| e.prioritization_fee > 0)
+        .map(|e| e.prioritization_fee)
+        .min_by(|a, b| a.cmp(b))
+        .unwrap_or(1);
+        
+    Ok(fee)
 }
 
 /// Update the first set_compute_unit_limit ix if it exists, else append a new one.


### PR DESCRIPTION
Summary:
This PR implements dynamic priority fee calculation for Solana transactions in the x402-reqwest crate, replacing the hardcoded 1 micro-lamport fee with a dynamic fee based on recent network activity.

Changes Made:
- Added get_priority_fee_micro_lamports function: Retrieves recent prioritization fees from the Solana RPC and selects the minimum non-zero fee
- Updated transaction building: Modified payment_payload method to use dynamic fees instead of hardcoded value
- Enhanced fee calculation: The system now queries recent prioritization fees for the specific accounts involved in the transaction

Technical Details:
Function: get_priority_fee_micro_lamports(rpc: &RpcClient, writeable_accounts: &[Pubkey]) -> Result<u64, X402PaymentsError>

Logic:
Fetches recent prioritization fees for the given accounts
    - Filters out zero fees
    - Returns the minimum valid fee, or 1 micro-lamport as fallback
Integration: Replaces the hardcoded 1 micro-lamport in build_message_to_simulate call

Benefits:
- Cost Optimization: Uses appropriate priority fees based on current network conditions
- Network Awareness: Adapts to Solana network state automatically
- Fallback Safety: Maintains minimum fee of 1 micro-lamport when no recent fees are available