### PR TITLE
fix: added no-entrypoint

### DIFF
--- a/examples/x402-reqwest-example/Cargo.toml
+++ b/examples/x402-reqwest-example/Cargo.toml
@@ -12,8 +12,8 @@ reqwest = { version = "0.12.20" }
 tokio = { version = "1.45.1" }
 dotenvy = { version = "0.15.7" }
 solana-sdk = { version = "2.3.1", features = ["full"] }
-spl-token = { version = "8.0.0" }
-spl-token-2022 = { version = "9.0.0" }
+spl-token = { version = "8.0.0" , features = ["no-entrypoint"] }
+spl-token-2022 = { version = "9.0.0" , features = ["no-entrypoint"] }
 solana-client = { version = "2.3.7" }
 
 bincode = { version = "1.3.3" } # Older version due to compatibility with solana-sdk


### PR DESCRIPTION
Since we are not using these crates in a solana program, we do not need to export `entrypoint`. 
Also, this prevents the compilation issue I faced at #13 because both of the crates were exposing the `entrypoint`