### PR TITLE
[FIX] `supported` endpoint network name compatibility

### DIFF
--- a/crates/x402-axum/src/layer.rs
+++ b/crates/x402-axum/src/layer.rs
@@ -479,7 +479,7 @@ where
                         let extra = supported
                             .kinds
                             .iter()
-                            .find(|s| s.network == network)
+                            .find(|s| s.network == network.to_string())
                             .cloned()
                             .and_then(|s| s.extra);
                         if let Some(extra) = extra {

--- a/src/chain/evm.rs
+++ b/src/chain/evm.rs
@@ -687,7 +687,7 @@ impl Facilitator for EvmProvider {
     /// Report payment kinds supported by this provider on its current network.
     async fn supported(&self) -> Result<SupportedPaymentKindsResponse, Self::Error> {
         let kinds = vec![SupportedPaymentKind {
-            network: self.network(),
+            network: self.network().to_string(),
             x402_version: X402Version::V1,
             scheme: Scheme::Exact,
             extra: None,

--- a/src/chain/solana.rs
+++ b/src/chain/solana.rs
@@ -491,7 +491,7 @@ impl Facilitator for SolanaProvider {
 
     async fn supported(&self) -> Result<SupportedPaymentKindsResponse, Self::Error> {
         let kinds = vec![SupportedPaymentKind {
-            network: self.network(),
+            network: self.network().to_string(),
             scheme: Scheme::Exact,
             x402_version: X402Version::V1,
             extra: Some(SupportedPaymentKindExtra {

--- a/src/facilitator_local.rs
+++ b/src/facilitator_local.rs
@@ -51,13 +51,13 @@ impl FacilitatorLocal {
                 NetworkProvider::Evm(_) => SupportedPaymentKind {
                     x402_version: X402Version::V1,
                     scheme: Scheme::Exact,
-                    network: *network,
+                    network: network.to_string(),
                     extra: None,
                 },
                 NetworkProvider::Solana(provider) => SupportedPaymentKind {
                     x402_version: X402Version::V1,
                     scheme: Scheme::Exact,
-                    network: *network,
+                    network: network.to_string(),
                     extra: Some(SupportedPaymentKindExtra {
                         fee_payer: provider.signer_address(),
                     }),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1399,7 +1399,7 @@ impl Display for PaymentRequiredResponse {
 pub struct SupportedPaymentKind {
     pub x402_version: X402Version,
     pub scheme: Scheme,
-    pub network: Network,
+    pub network: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extra: Option<SupportedPaymentKindExtra>,
 }


### PR DESCRIPTION
This pull request standardizes the type used for the `network` field within the `SupportedPaymentKind` struct and related logic. Previously, `network` was represented by the custom `Network` type; it is now consistently converted to a `String` throughout the codebase. This change improves serialization compatibility and simplifies handling network identifiers.

Type changes:

* Changed the `network` field in the `SupportedPaymentKind` struct from type `Network` to `String` to improve serialization and consistency.

Logic updates to use `String` for network:

* Updated all implementations of `Facilitator` (`EvmProvider`, `SolanaProvider`, and `FacilitatorLocal`) to convert network identifiers to `String` when constructing `SupportedPaymentKind` instances. [[1]](diffhunk://#diff-7487b9ca240078ecac9317c5cabeb7e51c486f004ce1aee1b4935706939ce1f4L690-R690) [[2]](diffhunk://#diff-42a669e82ae5dcef5c3b97a181c293c18addc08e316031681c65f047c72ef68cL494-R494) [[3]](diffhunk://#diff-dc3cce29f0526b87a078212e4cc13f20ca1ed1944df20c75c0d38541e99048aaL54-R60)
* Updated logic in `crates/x402-axum/src/layer.rs` to compare `network` fields as `String` values for correct matching.