### PR TITLE
feat: expose `supported_url()` to avoid having to reconstruct in callers

### DIFF
--- a/crates/x402-axum/src/facilitator_client.rs
+++ b/crates/x402-axum/src/facilitator_client.rs
@@ -173,6 +173,12 @@ impl FacilitatorClient {
         &self.settle_url
     }
 
+    /// Returns the computed `./supported` URL relative to [`FacilitatorClient::base_url`]
+    #[allow(dead_code)] // Public for consumption by downstream crates.
+    pub fn supported_url(&self) -> &Url {
+        &self.supported_url
+    }
+
     /// Returns any custom headers configured on the client.
     #[allow(dead_code)] // Public for consumption by downstream crates.
     pub fn headers(&self) -> &HeaderMap {


### PR DESCRIPTION
This change makes the interface consistent across all facilitator URLs and avoids the need to have to reconstruct the `/supported` in callers. 