### PR TITLE
feat: json input / output schema support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8927,6 +8927,7 @@ dependencies = [
  "axum",
  "dotenvy",
  "opentelemetry",
+ "serde_json",
  "tokio",
  "tower-http",
  "tracing",

--- a/examples/x402-axum-example/Cargo.toml
+++ b/examples/x402-axum-example/Cargo.toml
@@ -11,6 +11,7 @@ x402-axum = { version = "0.5", features = ["telemetry"] }
 axum = { version = "0.8.4" }
 tokio = { version = "1.45.0" }
 dotenvy = { version = "0.15.7" }
+serde_json = { version = "1.0" }
 
 # Tracing and OpenTelemetry
 tracing = { version = "0.1.41" }


### PR DESCRIPTION
This pull request adds support for configuring detailed input and output schemas for API endpoints in the `x402-axum` middleware. These schemas are now embedded in `PaymentRequirements.outputSchema`, enabling better API discovery, documentation, and client integration. The example application is updated to demonstrate usage of these new features, including public and private endpoints with rich schema metadata.

**Schema configuration and propagation:**

* Added `input_schema` and `output_schema` fields to `X402Middleware`, with new builder methods `with_input_schema()` and `with_output_schema()` for specifying endpoint schemas. These are combined and propagated to the `PaymentRequirements.outputSchema` field for each payment offer. [[1]](diffhunk://#diff-7acecfd0a746422f59be880a8f07f1d1638785a0dad2d3911bd1f55d104cdf49R107-R110) [[2]](diffhunk://#diff-7acecfd0a746422f59be880a8f07f1d1638785a0dad2d3911bd1f55d104cdf49R148-R149) [[3]](diffhunk://#diff-7acecfd0a746422f59be880a8f07f1d1638785a0dad2d3911bd1f55d104cdf49R231-R289) [[4]](diffhunk://#diff-7acecfd0a746422f59be880a8f07f1d1638785a0dad2d3911bd1f55d104cdf49R298-R313) [[5]](diffhunk://#diff-7acecfd0a746422f59be880a8f07f1d1638785a0dad2d3911bd1f55d104cdf49L257-R338) [[6]](diffhunk://#diff-7acecfd0a746422f59be880a8f07f1d1638785a0dad2d3911bd1f55d104cdf49L285-R366)

**Documentation and examples:**

* Updated `README.md` to document how to use input and output schemas, including examples and explanation of the `discoverable` flag for public/private endpoints.
* Enhanced the example application to demonstrate endpoints with input/output schemas, including a public weather API and a private internal API, and added corresponding handler implementations. [[1]](diffhunk://#diff-2e644433c948dcf6944bc9d5af717e3cdf1f7775015141cb510a6644154f242fR7) [[2]](diffhunk://#diff-2e644433c948dcf6944bc9d5af717e3cdf1f7775015141cb510a6644154f242fL40-R110) [[3]](diffhunk://#diff-2e644433c948dcf6944bc9d5af717e3cdf1f7775015141cb510a6644154f242fR172-R193)

**Dependency management:**

* Added `serde_json` as a dependency in the example application to support schema definition.