### PR TITLE
fix: register schemes for all chains matching a wildcard pattern

### DIFF
--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -173,20 +173,10 @@ impl ChainRegistry {
         self.0.get(&chain_id).cloned()
     }
 
-    /// Finds the first provider matching the given chain ID pattern.
-    ///
-    /// Useful for finding any provider within a namespace (e.g., any EVM chain)
-    /// or within a specific set of chains.
-    ///
-    /// Returns `None` if no provider matches the pattern.
-    pub fn by_chain_id_pattern(&self, pattern: &ChainIdPattern) -> Option<ChainProvider> {
-        self.0.iter().find_map(|(chain_id, provider)| {
-            if pattern.matches(chain_id) {
-                Some(provider.clone())
-            } else {
-                None
-            }
-        })
+    pub fn by_chain_id_pattern(&self, pattern: &ChainIdPattern) -> Vec<ChainProvider> {
+        self.0.iter().filter(|(chain_id, _)| pattern.matches(chain_id))
+            .map(|(_, provider)| provider.clone())
+            .collect()
     }
 }
 

--- a/src/scheme/mod.rs
+++ b/src/scheme/mod.rs
@@ -274,28 +274,29 @@ impl SchemeRegistry {
                     continue;
                 }
             };
-            let chain_provider = match chains.by_chain_id_pattern(&config.chains) {
-                Some(chain_provider) => chain_provider,
-                None => {
-                    tracing::warn!("No chain provider found for {}", config.chains);
-                    continue;
-                }
-            };
-            let chain_id = chain_provider.chain_id();
-            let handler = match blueprint.build(chain_provider, config.config.clone()) {
-                Ok(handler) => handler,
-                Err(err) => {
-                    tracing::error!("Error building scheme handler for {}: {}", config.id, err);
-                    continue;
-                }
-            };
-            let slug = SchemeHandlerSlug::new(
-                chain_id.clone(),
-                blueprint.x402_version(),
-                blueprint.scheme().to_string(),
-            );
-            tracing::info!(chain_id = %chain_id, scheme = %blueprint.scheme(), id=blueprint.id(), "Registered scheme handler");
-            handlers.insert(slug, handler);
+            let chain_providers = chains.by_chain_id_pattern(&config.chains);
+            if chain_providers.is_empty() {
+                tracing::warn!("No chain provider found for {}", config.chains);
+                continue;
+            }
+
+            for chain_provider in chain_providers {
+                let chain_id = chain_provider.chain_id();
+                let handler = match blueprint.build(chain_provider, config.config.clone()) {
+                    Ok(handler) => handler,
+                    Err(err) => {
+                        tracing::error!("Error building scheme handler for {}: {}", config.id, err);
+                        continue;
+                    }
+                };
+                let slug = SchemeHandlerSlug::new(
+                    chain_id.clone(),
+                    blueprint.x402_version(),
+                    blueprint.scheme().to_string(),
+                );
+                tracing::info!(chain_id = %chain_id, scheme = %blueprint.scheme(), id=blueprint.id(), "Registered scheme handler");
+                handlers.insert(slug, handler);
+            }
         }
         Self(handlers)
     }


### PR DESCRIPTION
# Fix: Register schemes for all chains matching a wildcard pattern

## Description
This PR fixes a bug where `SchemeRegistry` would only register a scheme handler for the *first* chain that matched a wildcard pattern (e.g., `eip155:*`), ignoring all subsequent matching chains. This caused `Unsupported scheme` errors for any chain other than the first one found in the configuration.

## Root Cause
- `ChainRegistry::by_chain_id_pattern` was using `find_map`, which returns `Option` (the first match).
- `SchemeRegistry::build` was expecting a single `ChainProvider` from that call.

## Changes
- **`src/chain/mod.rs`**: Updated `by_chain_id_pattern` to return `Vec<ChainProvider>` instead of `Option<ChainProvider>`. It now filters and collects *all* matching chains.
- **`src/scheme/mod.rs`**: Updated `SchemeRegistry::build` to iterate over the returned vector of chain providers and register a handler for each one.

## Issue
Fixes `Unsupported scheme` error when multiple chains are configured under a wildcard scheme (e.g., Polygon Mainnet and Amoy).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
1. Configured `config.json` with multiple EVM chains (e.g., `eip155:137` and `eip155:80002`).
2. Configured schemes with a wildcard pattern `"chains": "eip155:*"`.
3. Verified that the `/verify` endpoint now correctly processes requests for *both* chains, whereas previously it would fail for the second one.
