### PR TITLE
fix: make `description` and `mime_type` in `ResourceInfo` optional as per specs

### DIFF
--- a/crates/x402-axum/src/layer.rs
+++ b/crates/x402-axum/src/layer.rs
@@ -284,7 +284,7 @@ impl<TSource, TFacilitator> X402LayerBuilder<TSource, TFacilitator> {
     /// This is included in 402 responses to inform clients what they're paying for.
     pub fn with_description(mut self, description: String) -> Self {
         let mut new_resource = (*self.resource).clone();
-        new_resource.description = description;
+        new_resource.description = Some(description);
         self.resource = Arc::new(new_resource);
         self
     }
@@ -294,7 +294,7 @@ impl<TSource, TFacilitator> X402LayerBuilder<TSource, TFacilitator> {
     /// Defaults to `application/json` if not specified.
     pub fn with_mime_type(mut self, mime: String) -> Self {
         let mut new_resource = (*self.resource).clone();
-        new_resource.mime_type = mime;
+        new_resource.mime_type = Some(mime);
         self.resource = Arc::new(new_resource);
         self
     }

--- a/crates/x402-axum/src/paygate.rs
+++ b/crates/x402-axum/src/paygate.rs
@@ -58,9 +58,9 @@ use x402_types::util::Base64Bytes;
 #[derive(Debug, Clone)]
 pub struct ResourceInfoBuilder {
     /// Description of the protected resource
-    pub description: String,
+    pub description: Option<String>,
     /// MIME type of the protected resource
-    pub mime_type: String,
+    pub mime_type: Option<String>,
     /// Optional explicit URL of the protected resource
     pub url: Option<String>,
 }
@@ -68,8 +68,8 @@ pub struct ResourceInfoBuilder {
 impl Default for ResourceInfoBuilder {
     fn default() -> Self {
         Self {
-            description: "".to_string(),
-            mime_type: "application/json".to_string(),
+            description: None,
+            mime_type: None,
             url: None,
         }
     }
@@ -282,7 +282,7 @@ fn price_tag_to_v1_requirements_with_resource(
         network: price_tag.network.clone(),
         max_amount_required: price_tag.amount.clone(),
         resource: resource.url.clone(),
-        description: resource.description.clone(),
+        description: resource.description.clone().unwrap_or_default(),
         mime_type: resource.mime_type.clone(),
         output_schema: None,
         pay_to: price_tag.pay_to.clone(),

--- a/crates/x402-types/src/proto/v1.rs
+++ b/crates/x402-types/src/proto/v1.rs
@@ -376,7 +376,7 @@ pub struct PaymentRequirements<
     /// Human-readable description of the resource.
     pub description: String,
     /// MIME type of the resource.
-    pub mime_type: String,
+    pub mime_type: Option<String>,
     /// Optional JSON schema for the resource output.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_schema: Option<serde_json::Value>,

--- a/crates/x402-types/src/proto/v2.rs
+++ b/crates/x402-types/src/proto/v2.rs
@@ -100,12 +100,14 @@ pub type SettleResponse = v1::SettleResponse;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceInfo {
-    /// Human-readable description of the resource.
-    pub description: String,
-    /// MIME type of the resource content.
-    pub mime_type: String,
     /// URL of the resource.
     pub url: String,
+    /// Human-readable description of the resource.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// MIME type of the resource content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
 }
 
 /// Request to verify a V2 payment.


### PR DESCRIPTION
- Updated `ResourceInfoBuilder` and `ResourceInfo` to use `Option` types for `description` and `mime_type`.
- Adjusted defaults and serialization behavior to handle the optional fields.
- Ensured backward compatibility by providing default values where necessary.