### PR TITLE
fix(paygate): validate SettleResponse.success before serving protected resources

### DIFF
--- a/crates/x402-axum/src/paygate.rs
+++ b/crates/x402-axum/src/paygate.rs
@@ -542,6 +542,7 @@ where
             tracing::debug!("Settling payment before request execution");
 
             let settlement = self.settle_payment(&verify_request).await?;
+            validate_settlement(&settlement)?;
 
             let header_value = settlement_to_header(settlement)?;
 
@@ -574,6 +575,7 @@ where
             }
 
             let settlement = self.settle_payment(&verify_request).await?;
+            validate_settlement(&settlement)?;
 
             let header_value = settlement_to_header(settlement)?;
 
@@ -627,6 +629,38 @@ where
     let base64 = Base64Bytes::from(header_bytes).decode().ok()?;
     let value = serde_json::from_slice(base64.as_ref()).ok()?;
     Some(value)
+}
+
+/// Validates that a [`proto::SettleResponse`] indicates successful settlement.
+///
+/// The facilitator may return HTTP 200 with `{ "success": false }` when on-chain
+/// settlement fails (e.g., insufficient funds, reverted transaction). Without this
+/// check, the paygate would serve the protected resource despite failed payment.
+///
+/// # Fail-safe behavior
+///
+/// - `success: true` → Ok
+/// - `success: false` → Error with `errorReason` extracted if available
+/// - `success` missing or non-boolean → Error (non-compliant facilitator response)
+///
+/// See: <https://github.com/x402-rs/x402-rs/issues/65>
+fn validate_settlement(settlement: &proto::SettleResponse) -> Result<(), PaygateError> {
+    match settlement.0.get("success").and_then(|v| v.as_bool()) {
+        Some(true) => Ok(()),
+        Some(false) => {
+            let reason = settlement
+                .0
+                .get("errorReason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            Err(PaygateError::Settlement(format!(
+                "facilitator returned success: false (reason: {reason})"
+            )))
+        }
+        None => Err(PaygateError::Settlement(
+            "settlement response missing boolean 'success' field".into(),
+        )),
+    }
 }
 
 /// Converts a [`proto::SettleResponse`] into an HTTP header value.
@@ -852,5 +886,68 @@ where
         base_url: Option<&Url>,
     ) -> Vec<Self::PriceTag> {
         (self.callback)(headers, uri, base_url).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn settle_response(value: serde_json::Value) -> proto::SettleResponse {
+        proto::SettleResponse(value)
+    }
+
+    #[test]
+    fn validate_settlement_success_true() {
+        let resp = settle_response(json!({ "success": true, "txHash": "0xabc" }));
+        assert!(validate_settlement(&resp).is_ok());
+    }
+
+    #[test]
+    fn validate_settlement_success_false_with_reason() {
+        let resp = settle_response(json!({
+            "success": false,
+            "errorReason": "insufficient_funds"
+        }));
+        let err = validate_settlement(&resp).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("success: false"), "got: {msg}");
+        assert!(msg.contains("insufficient_funds"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_settlement_success_false_no_reason() {
+        let resp = settle_response(json!({ "success": false }));
+        let err = validate_settlement(&resp).unwrap_err();
+        assert!(err.to_string().contains("unknown"));
+    }
+
+    #[test]
+    fn validate_settlement_missing_success_field() {
+        let resp = settle_response(json!({ "txHash": "0xabc" }));
+        let err = validate_settlement(&resp).unwrap_err();
+        assert!(err.to_string().contains("missing boolean"));
+    }
+
+    #[test]
+    fn validate_settlement_success_is_string() {
+        let resp = settle_response(json!({ "success": "true" }));
+        let err = validate_settlement(&resp).unwrap_err();
+        assert!(err.to_string().contains("missing boolean"));
+    }
+
+    #[test]
+    fn validate_settlement_success_is_number() {
+        let resp = settle_response(json!({ "success": 1 }));
+        let err = validate_settlement(&resp).unwrap_err();
+        assert!(err.to_string().contains("missing boolean"));
+    }
+
+    #[test]
+    fn validate_settlement_empty_object() {
+        let resp = settle_response(json!({}));
+        let err = validate_settlement(&resp).unwrap_err();
+        assert!(err.to_string().contains("missing boolean"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #65 — `settlement_to_header()` serializes `SettleResponse` into the payment header without checking the `success` field. When a facilitator returns HTTP 200 with `{ "success": false }`, the paygate serves the protected resource despite failed on-chain settlement.

This is a parity gap with the official TypeScript implementation, which explicitly checks `!settleResponse.success` and returns 402 on failure.

## Changes

**`crates/x402-axum/src/paygate.rs`**

Add `validate_settlement()` that inspects the `success` field on `SettleResponse.0` (the inner `serde_json::Value`). Called in both execution paths of `handle_request_fallible`, between `settle_payment()` and `settlement_to_header()`:

```rust
let settlement = self.settle_payment(&verify_request).await?;
validate_settlement(&settlement)?;
let header_value = settlement_to_header(settlement)?;
```

### Fail-safe behavior

| `success` value | Result |
|---|---|
| `true` (bool) | `Ok(())` — proceed to serve resource |
| `false` (bool) | `Err` with `errorReason` extracted if available |
| Missing field | `Err` — non-compliant facilitator response |
| Non-boolean (`"true"`, `1`) | `Err` — malformed per spec |

### Design decisions

- **No changes to `SettleResponse` type.** It stays `pub struct SettleResponse(pub serde_json::Value)` — the check reads the inner Value without adding typed fields. Keeps the change minimal and avoids downstream type breakage.
- **`PaygateError::Settlement` reused.** The existing variant already handles settlement failures and maps to the right HTTP response (402). No new error variant needed.
- **Missing `success` → error, not pass-through.** Fail-safe. A conforming facilitator always includes this field; absence indicates a broken or non-compliant response.

## Impact

| Mode | Before | After |
|---|---|---|
| `settle_before_execution` | **High** — zero-balance wallets access resources | Settlement failure → `PaygateError::Settlement` → 402 |
| verify-first (default) | **Low** — verify catches most cases, narrow race window | Race window closed — both verify and settle must succeed |

## Tests

7 new unit tests in `paygate::tests`:

- `validate_settlement_success_true` — happy path
- `validate_settlement_success_false_with_reason` — extracts `errorReason`
- `validate_settlement_success_false_no_reason` — falls back to "unknown"
- `validate_settlement_missing_success_field` — fail-safe
- `validate_settlement_success_is_string` — rejects `"true"`
- `validate_settlement_success_is_number` — rejects `1`
- `validate_settlement_empty_object` — fail-safe

All 12 tests pass (`cargo test -p x402-axum`).

## Note

There is a pre-existing clippy warning on `main` (`derivable_impls` for `ResourceInfoBuilder::Default`) unrelated to this change.