### PR TITLE
feat: add facilitator verify/settle metrics via OTLP

### DIFF
--- a/crates/x402-facilitator-local/src/handlers.rs
+++ b/crates/x402-facilitator-local/src/handlers.rs
@@ -161,15 +161,60 @@ where
     A: Facilitator,
     A::Error: IntoResponse,
 {
+    #[cfg(feature = "telemetry")]
+    let start = std::time::Instant::now();
+
+    #[cfg(feature = "telemetry")]
+    let slug = body.scheme_handler_slug();
+
     match facilitator.verify(&body).await {
-        Ok(valid_response) => (StatusCode::OK, Json(valid_response)).into_response(),
+        Ok(valid_response) => {
+            #[cfg(feature = "telemetry")]
+            {
+                let duration = start.elapsed().as_secs_f64();
+                let (chain, scheme) = slug
+                    .as_ref()
+                    .map(|s| (s.chain_id.to_string(), s.name.clone()))
+                    .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
+                tracing::info!(
+                    monotonic_counter.facilitator_verify_requests_total = 1_u64,
+                    status = "ok",
+                    chain = %chain,
+                    scheme = %scheme,
+                );
+                tracing::info!(
+                    histogram.facilitator_verify_duration_seconds = duration,
+                    chain = %chain,
+                    scheme = %scheme,
+                );
+            }
+            (StatusCode::OK, Json(valid_response)).into_response()
+        }
         Err(error) => {
             #[cfg(feature = "telemetry")]
-            tracing::warn!(
-                error = ?error,
-                body = %serde_json::to_string(&body).unwrap_or_else(|_| "<can-not-serialize>".to_string()),
-                "Verification failed"
-            );
+            {
+                let duration = start.elapsed().as_secs_f64();
+                let (chain, scheme) = slug
+                    .as_ref()
+                    .map(|s| (s.chain_id.to_string(), s.name.clone()))
+                    .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
+                tracing::warn!(
+                    error = ?error,
+                    body = %serde_json::to_string(&body).unwrap_or_else(|_| "<can-not-serialize>".to_string()),
+                    "Verification failed"
+                );
+                tracing::info!(
+                    monotonic_counter.facilitator_verify_requests_total = 1_u64,
+                    status = "error",
+                    chain = %chain,
+                    scheme = %scheme,
+                );
+                tracing::info!(
+                    histogram.facilitator_verify_duration_seconds = duration,
+                    chain = %chain,
+                    scheme = %scheme,
+                );
+            }
             error.into_response()
         }
     }
@@ -196,15 +241,60 @@ where
     A: Facilitator,
     A::Error: IntoResponse,
 {
+    #[cfg(feature = "telemetry")]
+    let start = std::time::Instant::now();
+
+    #[cfg(feature = "telemetry")]
+    let slug = body.scheme_handler_slug();
+
     match facilitator.settle(&body).await {
-        Ok(valid_response) => (StatusCode::OK, Json(valid_response)).into_response(),
+        Ok(valid_response) => {
+            #[cfg(feature = "telemetry")]
+            {
+                let duration = start.elapsed().as_secs_f64();
+                let (chain, scheme) = slug
+                    .as_ref()
+                    .map(|s| (s.chain_id.to_string(), s.name.clone()))
+                    .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
+                tracing::info!(
+                    monotonic_counter.facilitator_settle_requests_total = 1_u64,
+                    status = "ok",
+                    chain = %chain,
+                    scheme = %scheme,
+                );
+                tracing::info!(
+                    histogram.facilitator_settle_duration_seconds = duration,
+                    chain = %chain,
+                    scheme = %scheme,
+                );
+            }
+            (StatusCode::OK, Json(valid_response)).into_response()
+        }
         Err(error) => {
             #[cfg(feature = "telemetry")]
-            tracing::warn!(
-                error = ?error,
-                body = %serde_json::to_string(&body).unwrap_or_else(|_| "<can-not-serialize>".to_string()),
-                "Settlement failed"
-            );
+            {
+                let duration = start.elapsed().as_secs_f64();
+                let (chain, scheme) = slug
+                    .as_ref()
+                    .map(|s| (s.chain_id.to_string(), s.name.clone()))
+                    .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
+                tracing::warn!(
+                    error = ?error,
+                    body = %serde_json::to_string(&body).unwrap_or_else(|_| "<can-not-serialize>".to_string()),
+                    "Settlement failed"
+                );
+                tracing::info!(
+                    monotonic_counter.facilitator_settle_requests_total = 1_u64,
+                    status = "error",
+                    chain = %chain,
+                    scheme = %scheme,
+                );
+                tracing::info!(
+                    histogram.facilitator_settle_duration_seconds = duration,
+                    chain = %chain,
+                    scheme = %scheme,
+                );
+            }
             error.into_response()
         }
     }


### PR DESCRIPTION
## Summary

Adds application-level metrics for the verify and settle endpoints using the existing `tracing-opentelemetry` `MetricsLayer`. Metrics are emitted as OTLP and can be collected by a Prometheus exporter sidecar (OTel Collector).

### Metrics added

| Metric | Type | Labels |
|--------|------|--------|
| `facilitator_verify_requests_total` | counter | status, chain, scheme |
| `facilitator_verify_duration_seconds` | histogram | chain, scheme |
| `facilitator_settle_requests_total` | counter | status, chain |
| `facilitator_settle_duration_seconds` | histogram | chain |

### How it works

Uses `tracing` events with `monotonic_counter.` and `histogram.` prefixes, which the `MetricsLayer` (already configured in the telemetry stack) automatically converts into OTel metrics. These are exported via the existing `SdkMeterProvider` OTLP exporter.

### Context

We have a Grafana dashboard expecting these metrics to monitor facilitator health. Currently the app only emits traces/spans but no metrics, so the dashboard is empty.

## Test plan

- [ ] `cargo check` passes
- [ ] `cargo test` passes
- [ ] Deploy with OTel Collector sidecar and verify metrics appear on Prometheus endpoint
- [ ] Confirm Grafana dashboard panels populate