### PR TITLE
feat(x402-axum): add from_facilitator constructor to X402Middleware

### DIFF
--- a/crates/x402-axum/src/layer.rs
+++ b/crates/x402-axum/src/layer.rs
@@ -84,6 +84,25 @@ pub struct X402Middleware<F> {
 }
 
 impl<F> X402Middleware<F> {
+    /// Creates middleware from a pre-configured facilitator instance.
+    ///
+    /// Use this when you need to configure the facilitator before constructing
+    /// the middleware — for example, to set custom auth headers on a
+    /// [`FacilitatorClient`] for the Coinbase CDP facilitator:
+    ///
+    /// ```rust,ignore
+    /// let client = FacilitatorClient::try_new(url)?
+    ///     .with_headers(cdp_headers);
+    /// let x402 = X402Middleware::from_facilitator(Arc::new(client));
+    /// ```
+    pub fn from_facilitator(facilitator: F) -> Self {
+        Self {
+            facilitator,
+            base_url: None,
+            settle_before_execution: false,
+        }
+    }
+
     pub fn facilitator(&self) -> &F {
         &self.facilitator
     }


### PR DESCRIPTION
## Summary

Adds a `from_facilitator()` constructor to `X402Middleware` that accepts a pre-configured facilitator instance.

This is needed when the facilitator requires custom configuration before being passed to the middleware — for example, setting auth headers on a `FacilitatorClient` for the Coinbase CDP facilitator:

```rust
let client = FacilitatorClient::try_new(url)?
    .with_headers(cdp_headers);
let x402 = X402Middleware::from_facilitator(Arc::new(client));
```

Currently, all constructors (`new`, `try_new`, `TryFrom`) create the `FacilitatorClient` internally with no way to configure it beforehand. `FacilitatorClient::with_headers()` exists but there's no way to pass the resulting client into the middleware.

## Changes

- Add `pub fn from_facilitator(facilitator: F) -> Self` to `impl<F> X402Middleware<F>`
- Backwards compatible, no breaking changes

## Motivation

Using the Coinbase CDP hosted facilitator (`api.cdp.coinbase.com/platform/v2/x402`) requires `CDP-API-KEY-ID` and `CDP-API-KEY-SECRET` headers on every request. Without this constructor, the only workaround is forking the crate.