### PR TITLE
Add EIP-2612-aware Permit2 support metadata for exact EVM

### DIFF
--- a/.github/workflows/fork-ci.yaml
+++ b/.github/workflows/fork-ci.yaml
@@ -1,0 +1,77 @@
+name: Fork — Build and publish Docker image
+
+on:
+  push:
+    branches: ['main', 'feat/*']
+    tags: ['v*']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/x402-facilitator
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run tests
+        run: cargo test --workspace
+
+      - name: Run clippy
+        run: cargo clippy --workspace -- -D warnings
+
+  build:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=dev,enable={{is_default_branch}}
+            type=ref,event=branch,suffix=-{{sha}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5840,6 +5840,12 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -7757,6 +7763,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.11.0",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.11.0",
+ "hex",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7765,8 +7794,11 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs",
+ "protobuf",
  "thiserror 1.0.69",
 ]
 
@@ -7854,6 +7886,12 @@ checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost 0.13.5",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psl-types"
@@ -8671,6 +8709,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -8678,7 +8729,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -11529,7 +11580,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -11570,7 +11621,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.60.2",
 ]
 
@@ -13496,6 +13547,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
+ "prometheus",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ x402-reqwest = { version = "1.0", path = "crates/x402-reqwest" }
 x402-types = { version = "1.0", path = "crates/x402-types" }
 
 alloy-primitives = { version = "1.4.1" } # To represent token amounts
+prometheus = { version = "0.13", features = ["process"] }
 async-trait = { version = "0.1" }
 axum = { version = "0.8" }
 dotenvy = { version = "0.15.7" }

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_exact/client.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_exact/client.rs
@@ -250,6 +250,7 @@ where
                 v2::PaymentPayload {
                     x402_version: v2::X402Version2,
                     accepted: self.requirements_json.clone(),
+                    extensions: Default::default(),
                     resource: self.resource_info.clone(),
                     payload: ExactEvmPayload::Eip3009(evm_payload),
                 }
@@ -268,6 +269,7 @@ where
                 v2::PaymentPayload {
                     x402_version: v2::X402Version2,
                     accepted: self.requirements_json.clone(),
+                    extensions: Default::default(),
                     resource: self.resource_info.clone(),
                     payload: ExactEvmPayload::Permit2(permit2_payload),
                 }

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_exact/facilitator/mod.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_exact/facilitator/mod.rs
@@ -8,6 +8,7 @@ pub mod eip3009;
 pub mod permit2;
 
 use alloy_provider::Provider;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use x402_types::chain::ChainProviderOps;
 use x402_types::proto;
@@ -22,6 +23,29 @@ use crate::v1_eip155_exact::ExactScheme;
 use crate::v1_eip155_exact::facilitator::Eip155ExactError;
 use crate::v2_eip155_exact::types;
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct V2Eip155ExactFacilitatorConfig {
+    #[serde(default)]
+    pub supported_extensions: Vec<String>,
+}
+
+impl V2Eip155ExactFacilitatorConfig {
+    pub fn supports_extension(&self, extension: &str) -> bool {
+        self.supported_extensions
+            .iter()
+            .any(|candidate| candidate == extension)
+    }
+
+    pub fn supported_extensions_json(&self) -> Option<serde_json::Value> {
+        if self.supported_extensions.is_empty() {
+            None
+        } else {
+            Some(serde_json::json!({ "extensions": self.supported_extensions }))
+        }
+    }
+}
+
 impl<P> X402SchemeFacilitatorBuilder<P> for V2Eip155Exact
 where
     P: Eip155MetaTransactionProvider + ChainProviderOps + Send + Sync + 'static,
@@ -30,9 +54,13 @@ where
     fn build(
         &self,
         provider: P,
-        _config: Option<serde_json::Value>,
+        config: Option<serde_json::Value>,
     ) -> Result<Box<dyn X402SchemeFacilitator>, Box<dyn std::error::Error>> {
-        Ok(Box::new(V2Eip155ExactFacilitator::new(provider)))
+        let config = config
+            .map(serde_json::from_value::<V2Eip155ExactFacilitatorConfig>)
+            .transpose()?
+            .unwrap_or_default();
+        Ok(Box::new(V2Eip155ExactFacilitator::new(provider, config)))
     }
 }
 
@@ -48,12 +76,13 @@ where
 ///   and [`ChainProviderOps`]
 pub struct V2Eip155ExactFacilitator<P> {
     provider: P,
+    config: V2Eip155ExactFacilitatorConfig,
 }
 
 impl<P> V2Eip155ExactFacilitator<P> {
     /// Creates a new V2 EIP-155 exact scheme facilitator with the given provider.
-    pub fn new(provider: P) -> Self {
-        Self { provider }
+    pub fn new(provider: P, config: V2Eip155ExactFacilitatorConfig) -> Self {
+        Self { provider, config }
     }
 }
 
@@ -91,6 +120,7 @@ where
                     &self.provider,
                     &payment_payload,
                     &payment_requirements,
+                    &self.config,
                 )
                 .await?
             }
@@ -125,6 +155,7 @@ where
                     &self.provider,
                     &payment_payload,
                     &payment_requirements,
+                    &self.config,
                 )
                 .await?
             }
@@ -138,7 +169,7 @@ where
             x402_version: v2::X402Version2.into(),
             scheme: ExactScheme.to_string(),
             network: chain_id.clone().into(),
-            extra: None,
+            extra: self.config.supported_extensions_json(),
         }];
         let signers = {
             let mut signers = HashMap::with_capacity(1);
@@ -147,8 +178,28 @@ where
         };
         Ok(proto::SupportedResponse {
             kinds,
-            extensions: Vec::new(),
+            extensions: self.config.supported_extensions.clone(),
             signers,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::V2Eip155ExactFacilitatorConfig;
+
+    #[test]
+    fn config_reports_supported_extensions() {
+        let config = V2Eip155ExactFacilitatorConfig {
+            supported_extensions: vec!["eip2612GasSponsoring".to_string()],
+        };
+
+        assert!(config.supports_extension("eip2612GasSponsoring"));
+        assert_eq!(
+            config.supported_extensions_json(),
+            Some(serde_json::json!({
+                "extensions": ["eip2612GasSponsoring"]
+            }))
+        );
     }
 }

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_exact/facilitator/permit2.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_exact/facilitator/permit2.rs
@@ -1,9 +1,12 @@
-use alloy_primitives::{Address, TxHash, U256};
+use alloy_primitives::{Address, Bytes, TxHash, U256};
 use alloy_provider::bindings::IMulticall3;
 use alloy_provider::{MULTICALL3_ADDRESS, MulticallItem, Provider};
 use alloy_rpc_types_eth::TransactionReceipt;
 use alloy_sol_types::{SolCall, SolStruct, eip712_domain};
+use serde::Deserialize;
+use std::collections::HashMap;
 use x402_types::chain::ChainProviderOps;
+use x402_types::timestamp::UnixTimestamp;
 use x402_types::proto::{PaymentVerificationError, v2};
 use x402_types::scheme::X402SchemeFacilitatorError;
 
@@ -19,17 +22,118 @@ use crate::v1_eip155_exact::{
     Eip155ExactError, StructuredSignature, VALIDATOR_ADDRESS, Validator6492, assert_enough_value,
     assert_time, is_contract_deployed, tx_hash_from_receipt,
 };
+use crate::v2_eip155_exact::facilitator::V2Eip155ExactFacilitatorConfig;
 use crate::v2_eip155_exact::eip3009::assert_requirements_match;
 use crate::v2_eip155_exact::types::{
     ISignatureTransfer, Permit2PaymentPayload, Permit2PaymentRequirements,
     PermitWitnessTransferFrom, X402ExactPermit2Proxy, x402BasePermit2Proxy,
 };
 
+pub const EXTENSION_EIP2612_GAS_SPONSORING: &str = "eip2612GasSponsoring";
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Eip2612GasSponsoringInfo {
+    from: crate::chain::ChecksummedAddress,
+    asset: crate::chain::ChecksummedAddress,
+    spender: crate::chain::ChecksummedAddress,
+    #[serde(with = "crate::decimal_u256")]
+    amount: U256,
+    #[serde(rename = "nonce")]
+    #[serde(with = "crate::decimal_u256")]
+    _nonce: U256,
+    deadline: UnixTimestamp,
+    signature: Bytes,
+    version: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Eip2612GasSponsoringExtension {
+    info: Eip2612GasSponsoringInfo,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum Eip2612GasSponsoringWire {
+    Wrapped(Eip2612GasSponsoringExtension),
+    BareInfo(Eip2612GasSponsoringInfo),
+}
+
+impl Eip2612GasSponsoringWire {
+    fn into_info(self) -> Eip2612GasSponsoringInfo {
+        match self {
+            Self::Wrapped(extension) => extension.info,
+            Self::BareInfo(info) => info,
+        }
+    }
+}
+
+fn extract_eip2612_gas_sponsoring_info(
+    extensions: &HashMap<String, serde_json::Value>,
+) -> Result<Option<Eip2612GasSponsoringInfo>, PaymentVerificationError> {
+    let Some(raw) = extensions.get(EXTENSION_EIP2612_GAS_SPONSORING) else {
+        return Ok(None);
+    };
+    let parsed: Eip2612GasSponsoringWire = serde_json::from_value(raw.clone())?;
+    Ok(Some(parsed.into_info()))
+}
+
+fn split_eip2612_signature(signature: &Bytes) -> Result<(u8, [u8; 32], [u8; 32]), Eip155ExactError> {
+    if signature.len() != 65 {
+        return Err(PaymentVerificationError::InvalidFormat(
+            "eip2612 signature must be 65 bytes".to_string(),
+        )
+        .into());
+    }
+
+    let mut r = [0u8; 32];
+    let mut s = [0u8; 32];
+    r.copy_from_slice(&signature[..32]);
+    s.copy_from_slice(&signature[32..64]);
+    Ok((signature[64], r, s))
+}
+
+fn validate_eip2612_gas_sponsoring_info(
+    info: &Eip2612GasSponsoringInfo,
+    payment_payload: &Permit2PaymentPayload,
+) -> Result<(), PaymentVerificationError> {
+    let authorization = &payment_payload.payload.permit_2_authorization;
+    let accepted = &payment_payload.accepted;
+
+    if info.from != authorization.from {
+        return Err(PaymentVerificationError::InvalidFormat(
+            "eip2612 from does not match permit2 payer".to_string(),
+        ));
+    }
+    if info.asset != accepted.asset {
+        return Err(PaymentVerificationError::AssetMismatch);
+    }
+    if info.spender.0 != PERMIT2_ADDRESS {
+        return Err(PaymentVerificationError::InvalidFormat(
+            "eip2612 spender must be canonical Permit2".to_string(),
+        ));
+    }
+    if info.amount != authorization.permitted.amount {
+        return Err(PaymentVerificationError::InvalidPaymentAmount);
+    }
+    if info.deadline < UnixTimestamp::now() + 6 {
+        return Err(PaymentVerificationError::Expired);
+    }
+    if info.version.trim().is_empty() {
+        return Err(PaymentVerificationError::InvalidFormat(
+            "eip2612 version is required".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg_attr(feature = "telemetry", instrument(skip_all, err))]
 pub async fn verify_permit2_payment<P: Eip155MetaTransactionProvider + ChainProviderOps>(
     provider: &P,
     payment_payload: &Permit2PaymentPayload,
     payment_requirements: &Permit2PaymentRequirements,
+    config: &V2Eip155ExactFacilitatorConfig,
 ) -> Result<v2::VerifyResponse, Eip155ExactError> {
     // 1. Verify offchain constraints
     assert_offchain_valid(payment_payload, payment_requirements)?;
@@ -37,7 +141,13 @@ pub async fn verify_permit2_payment<P: Eip155MetaTransactionProvider + ChainProv
     // 2. Verify onchain constraints
     let authorization = &payment_payload.payload.permit_2_authorization;
     let payer: Address = authorization.from.into();
-    assert_onchain_exact_permit2(provider.inner(), provider.chain(), payment_payload).await?;
+    let eip2612 = if config.supports_extension(EXTENSION_EIP2612_GAS_SPONSORING) {
+        extract_eip2612_gas_sponsoring_info(&payment_payload.extensions)?
+    } else {
+        None
+    };
+    assert_onchain_exact_permit2(provider.inner(), provider.chain(), payment_payload, eip2612.as_ref())
+        .await?;
 
     Ok(v2::VerifyResponse::valid(payer.to_string()))
 }
@@ -47,6 +157,7 @@ pub async fn settle_permit2_payment<P, E>(
     provider: &P,
     payment_payload: &Permit2PaymentPayload,
     payment_requirements: &Permit2PaymentRequirements,
+    config: &V2Eip155ExactFacilitatorConfig,
 ) -> Result<v2::SettleResponse, X402SchemeFacilitatorError>
 where
     P: Eip155MetaTransactionProvider<Error = E> + ChainProviderOps,
@@ -56,7 +167,12 @@ where
     assert_offchain_valid(payment_payload, payment_requirements)?;
 
     // 2. Try settle
-    let tx_hash = settle_exact_permit2(provider, payment_payload).await?;
+    let eip2612 = if config.supports_extension(EXTENSION_EIP2612_GAS_SPONSORING) {
+        extract_eip2612_gas_sponsoring_info(&payment_payload.extensions)?
+    } else {
+        None
+    };
+    let tx_hash = settle_exact_permit2(provider, payment_payload, eip2612.as_ref()).await?;
     let authorization = &payment_payload.payload.permit_2_authorization;
     let payer = authorization.from;
     let network = &payment_payload.accepted.network;
@@ -155,10 +271,11 @@ pub async fn assert_onchain_balance<P: Provider>(
 }
 
 #[cfg_attr(feature = "telemetry", instrument(skip_all, err))]
-pub async fn assert_onchain_exact_permit2<P: Provider>(
+async fn assert_onchain_exact_permit2<P: Provider>(
     provider: &P,
     chain_reference: &Eip155ChainReference,
     payment_payload: &Permit2PaymentPayload,
+    eip2612: Option<&Eip2612GasSponsoringInfo>,
 ) -> Result<(), Eip155ExactError> {
     let authorization = &payment_payload.payload.permit_2_authorization;
     let payer = authorization.from.0;
@@ -167,11 +284,19 @@ pub async fn assert_onchain_exact_permit2<P: Provider>(
 
     let token_contract = IERC20::new(asset_address, provider);
 
-    // Allowance from payer to Permit2 contract is enough
-    let onchain_allowance_fut = assert_onchain_allowance(&token_contract, payer, required_amount);
     // User balance is enough
-    let onchain_balance_fut = assert_onchain_balance(&token_contract, payer, required_amount);
-    tokio::try_join!(onchain_allowance_fut, onchain_balance_fut)?;
+    assert_onchain_balance(&token_contract, payer, required_amount).await?;
+
+    let has_allowance = assert_onchain_allowance(&token_contract, payer, required_amount)
+        .await
+        .is_ok();
+    let should_use_eip2612 = !has_allowance && eip2612.is_some();
+    if !has_allowance && !should_use_eip2612 {
+        return Err(PaymentVerificationError::InsufficientAllowance.into());
+    }
+    if let Some(info) = eip2612 {
+        validate_eip2612_gas_sponsoring_info(info, payment_payload)?;
+    }
 
     // ... and below is a check if we can do the settle
 
@@ -202,6 +327,18 @@ pub async fn assert_onchain_exact_permit2<P: Provider>(
     )?;
 
     let exact_permit2_proxy = X402ExactPermit2Proxy::new(EXACT_PERMIT2_PROXY_ADDRESS, provider);
+    let eip2612_permit = if let Some(info) = eip2612 {
+        let (v, r, s) = split_eip2612_signature(&info.signature)?;
+        Some(x402BasePermit2Proxy::EIP2612Permit {
+            value: info.amount,
+            deadline: U256::from(info.deadline.as_secs()),
+            r: r.into(),
+            s: s.into(),
+            v,
+        })
+    } else {
+        None
+    };
     match structured_signature {
         StructuredSignature::EIP6492 {
             factory: _,
@@ -218,38 +355,82 @@ pub async fn assert_onchain_exact_permit2<P: Provider>(
                 deadline: permit_witness_transfer_from.deadline,
             };
             let witness = permit_witness_transfer_from.witness;
-            let settle_call =
-                exact_permit2_proxy.settle(permit_transfer_from, payer, witness, inner);
-            let aggregate3 = provider
-                .multicall()
-                .add(is_valid_signature_call)
-                .add(settle_call);
-            let aggregate3_call = aggregate3.aggregate3();
-            #[cfg(feature = "telemetry")]
-            let (is_valid_signature_result, transfer_result) = aggregate3_call
-                .instrument(tracing::info_span!("multi_call_settle_exact_permit2",
-                    from = %payer,
-                    to = %authorization.witness.to,
-                    value = %authorization.permitted.amount,
-                    valid_after = %authorization.witness.valid_after,
-                    valid_before = %authorization.deadline,
-                    nonce = %authorization.nonce,
-                    token_contract = %authorization.permitted.token,
-                    otel.kind = "client",
-                ))
-                .await?;
-            #[cfg(not(feature = "telemetry"))]
-            let (is_valid_signature_result, transfer_result) = aggregate3_call.await?;
-            let is_valid_signature_result = is_valid_signature_result
-                .map_err(|e| PaymentVerificationError::InvalidSignature(e.to_string()))?;
-            if !is_valid_signature_result {
-                return Err(PaymentVerificationError::InvalidSignature(
-                    "Chain reported signature to be invalid".to_string(),
-                )
-                .into());
+            if let Some(permit2612) = eip2612_permit.clone() {
+                let settle_call = exact_permit2_proxy.settleWithPermit(
+                    permit2612,
+                    permit_transfer_from,
+                    payer,
+                    witness,
+                    inner,
+                );
+                let aggregate3 = provider
+                    .multicall()
+                    .add(is_valid_signature_call)
+                    .add(settle_call);
+                let aggregate3_call = aggregate3.aggregate3();
+                #[cfg(feature = "telemetry")]
+                let (is_valid_signature_result, transfer_result) = aggregate3_call
+                    .instrument(tracing::info_span!("multi_call_settle_exact_permit2",
+                        from = %payer,
+                        to = %authorization.witness.to,
+                        value = %authorization.permitted.amount,
+                        valid_after = %authorization.witness.valid_after,
+                        valid_before = %authorization.deadline,
+                        nonce = %authorization.nonce,
+                        token_contract = %authorization.permitted.token,
+                        otel.kind = "client",
+                    ))
+                    .await?;
+                #[cfg(not(feature = "telemetry"))]
+                let (is_valid_signature_result, transfer_result) = aggregate3_call.await?;
+                let is_valid_signature_result = is_valid_signature_result
+                    .map_err(|e| PaymentVerificationError::InvalidSignature(e.to_string()))?;
+                if !is_valid_signature_result {
+                    return Err(PaymentVerificationError::InvalidSignature(
+                        "Chain reported signature to be invalid".to_string(),
+                    )
+                    .into());
+                }
+                transfer_result
+                    .map_err(|e| PaymentVerificationError::TransactionSimulation(e.to_string()))?;
+            } else {
+                let settle_call = exact_permit2_proxy.settle(
+                    permit_transfer_from,
+                    payer,
+                    witness,
+                    inner,
+                );
+                let aggregate3 = provider
+                    .multicall()
+                    .add(is_valid_signature_call)
+                    .add(settle_call);
+                let aggregate3_call = aggregate3.aggregate3();
+                #[cfg(feature = "telemetry")]
+                let (is_valid_signature_result, transfer_result) = aggregate3_call
+                    .instrument(tracing::info_span!("multi_call_settle_exact_permit2",
+                        from = %payer,
+                        to = %authorization.witness.to,
+                        value = %authorization.permitted.amount,
+                        valid_after = %authorization.witness.valid_after,
+                        valid_before = %authorization.deadline,
+                        nonce = %authorization.nonce,
+                        token_contract = %authorization.permitted.token,
+                        otel.kind = "client",
+                    ))
+                    .await?;
+                #[cfg(not(feature = "telemetry"))]
+                let (is_valid_signature_result, transfer_result) = aggregate3_call.await?;
+                let is_valid_signature_result = is_valid_signature_result
+                    .map_err(|e| PaymentVerificationError::InvalidSignature(e.to_string()))?;
+                if !is_valid_signature_result {
+                    return Err(PaymentVerificationError::InvalidSignature(
+                        "Chain reported signature to be invalid".to_string(),
+                    )
+                    .into());
+                }
+                transfer_result
+                    .map_err(|e| PaymentVerificationError::TransactionSimulation(e.to_string()))?;
             }
-            transfer_result
-                .map_err(|e| PaymentVerificationError::TransactionSimulation(e.to_string()))?;
             Ok(())
         }
         StructuredSignature::EOA(signature) => {
@@ -259,28 +440,54 @@ pub async fn assert_onchain_exact_permit2<P: Provider>(
                 deadline: permit_witness_transfer_from.deadline,
             };
             let witness = permit_witness_transfer_from.witness;
-            let settle_call = exact_permit2_proxy.settle(
-                permit_transfer_from,
-                payer,
-                witness,
-                signature.as_bytes().into(),
-            );
-            let settle_call_fut = settle_call.call().into_future();
-            #[cfg(feature = "telemetry")]
-            settle_call_fut
-                .instrument(tracing::info_span!("call_settle_exact_permit2",
-                    from = %payer,
-                    to = %authorization.witness.to,
-                    value = %authorization.permitted.amount,
-                    valid_after = %authorization.witness.valid_after,
-                    valid_before = %authorization.deadline,
-                    nonce = %authorization.nonce,
-                    token_contract = %authorization.permitted.token,
-                    otel.kind = "client",
-                ))
-                .await?;
-            #[cfg(not(feature = "telemetry"))]
-            settle_call_fut.await?;
+            if let Some(permit2612) = eip2612_permit.clone() {
+                let settle_call = exact_permit2_proxy.settleWithPermit(
+                    permit2612,
+                    permit_transfer_from,
+                    payer,
+                    witness,
+                    signature.as_bytes().into(),
+                );
+                let settle_call_fut = settle_call.call().into_future();
+                #[cfg(feature = "telemetry")]
+                settle_call_fut
+                    .instrument(tracing::info_span!("call_settle_exact_permit2",
+                        from = %payer,
+                        to = %authorization.witness.to,
+                        value = %authorization.permitted.amount,
+                        valid_after = %authorization.witness.valid_after,
+                        valid_before = %authorization.deadline,
+                        nonce = %authorization.nonce,
+                        token_contract = %authorization.permitted.token,
+                        otel.kind = "client",
+                    ))
+                    .await?;
+                #[cfg(not(feature = "telemetry"))]
+                settle_call_fut.await?;
+            } else {
+                let settle_call = exact_permit2_proxy.settle(
+                    permit_transfer_from,
+                    payer,
+                    witness,
+                    signature.as_bytes().into(),
+                );
+                let settle_call_fut = settle_call.call().into_future();
+                #[cfg(feature = "telemetry")]
+                settle_call_fut
+                    .instrument(tracing::info_span!("call_settle_exact_permit2",
+                        from = %payer,
+                        to = %authorization.witness.to,
+                        value = %authorization.permitted.amount,
+                        valid_after = %authorization.witness.valid_after,
+                        valid_before = %authorization.deadline,
+                        nonce = %authorization.nonce,
+                        token_contract = %authorization.permitted.token,
+                        otel.kind = "client",
+                    ))
+                    .await?;
+                #[cfg(not(feature = "telemetry"))]
+                settle_call_fut.await?;
+            }
             Ok(())
         }
         StructuredSignature::EIP1271(signature) => {
@@ -290,32 +497,59 @@ pub async fn assert_onchain_exact_permit2<P: Provider>(
                 deadline: permit_witness_transfer_from.deadline,
             };
             let witness = permit_witness_transfer_from.witness;
-            let settle_call =
-                exact_permit2_proxy.settle(permit_transfer_from, payer, witness, signature);
-            let settle_call_fut = settle_call.call().into_future();
-            #[cfg(feature = "telemetry")]
-            settle_call_fut
-                .instrument(tracing::info_span!("call_settle_exact_permit2",
-                    from = %payer,
-                    to = %authorization.witness.to,
-                    value = %authorization.permitted.amount,
-                    valid_after = %authorization.witness.valid_after,
-                    valid_before = %authorization.deadline,
-                    nonce = %authorization.nonce,
-                    token_contract = %authorization.permitted.token,
-                    otel.kind = "client",
-                ))
-                .await?;
-            #[cfg(not(feature = "telemetry"))]
-            settle_call_fut.await?;
+            if let Some(permit2612) = eip2612_permit {
+                let settle_call = exact_permit2_proxy.settleWithPermit(
+                    permit2612,
+                    permit_transfer_from,
+                    payer,
+                    witness,
+                    signature,
+                );
+                let settle_call_fut = settle_call.call().into_future();
+                #[cfg(feature = "telemetry")]
+                settle_call_fut
+                    .instrument(tracing::info_span!("call_settle_exact_permit2",
+                        from = %payer,
+                        to = %authorization.witness.to,
+                        value = %authorization.permitted.amount,
+                        valid_after = %authorization.witness.valid_after,
+                        valid_before = %authorization.deadline,
+                        nonce = %authorization.nonce,
+                        token_contract = %authorization.permitted.token,
+                        otel.kind = "client",
+                    ))
+                    .await?;
+                #[cfg(not(feature = "telemetry"))]
+                settle_call_fut.await?;
+            } else {
+                let settle_call =
+                    exact_permit2_proxy.settle(permit_transfer_from, payer, witness, signature);
+                let settle_call_fut = settle_call.call().into_future();
+                #[cfg(feature = "telemetry")]
+                settle_call_fut
+                    .instrument(tracing::info_span!("call_settle_exact_permit2",
+                        from = %payer,
+                        to = %authorization.witness.to,
+                        value = %authorization.permitted.amount,
+                        valid_after = %authorization.witness.valid_after,
+                        valid_before = %authorization.deadline,
+                        nonce = %authorization.nonce,
+                        token_contract = %authorization.permitted.token,
+                        otel.kind = "client",
+                    ))
+                    .await?;
+                #[cfg(not(feature = "telemetry"))]
+                settle_call_fut.await?;
+            }
             Ok(())
         }
     }
 }
 
-pub async fn settle_exact_permit2<P, E>(
+async fn settle_exact_permit2<P, E>(
     provider: &P,
     payment_payload: &Permit2PaymentPayload,
+    eip2612: Option<&Eip2612GasSponsoringInfo>,
 ) -> Result<TxHash, Eip155ExactError>
 where
     P: Eip155MetaTransactionProvider<Error = E> + ChainProviderOps,
@@ -351,6 +585,18 @@ where
 
     let exact_permit2_proxy =
         X402ExactPermit2Proxy::new(EXACT_PERMIT2_PROXY_ADDRESS, provider.inner());
+    let eip2612_permit = if let Some(info) = eip2612 {
+        let (v, r, s) = split_eip2612_signature(&info.signature)?;
+        Some(x402BasePermit2Proxy::EIP2612Permit {
+            value: info.amount,
+            deadline: U256::from(info.deadline.as_secs()),
+            r: r.into(),
+            s: s.into(),
+            v,
+        })
+    } else {
+        None
+    };
     let permit_transfer_from = ISignatureTransfer::PermitTransferFrom {
         permitted: permit_witness_transfer_from.permitted,
         nonce: permit_witness_transfer_from.nonce,
@@ -366,14 +612,26 @@ where
             original: _,
         } => {
             let is_contract_deployed = is_contract_deployed(provider.inner(), &payer).await?;
-            let settle_call =
-                exact_permit2_proxy.settle(permit_transfer_from, payer, witness, inner.clone());
+            let (settle_target, settle_calldata) = if let Some(permit2612) = eip2612_permit.clone() {
+                let settle_call = exact_permit2_proxy.settleWithPermit(
+                    permit2612,
+                    permit_transfer_from,
+                    payer,
+                    witness,
+                    inner.clone(),
+                );
+                (settle_call.target(), settle_call.calldata().clone())
+            } else {
+                let settle_call =
+                    exact_permit2_proxy.settle(permit_transfer_from, payer, witness, inner.clone());
+                (settle_call.target(), settle_call.calldata().clone())
+            };
             if is_contract_deployed {
                 let tx_fut = Eip155MetaTransactionProvider::send_transaction(
                     provider,
                     MetaTransaction {
-                        to: settle_call.target(),
-                        calldata: settle_call.calldata().clone(),
+                        to: settle_target,
+                        calldata: settle_calldata.clone(),
                         confirmations: 1,
                     },
                 );
@@ -406,8 +664,8 @@ where
                 };
                 let transfer_with_authorization_call = IMulticall3::Call3 {
                     allowFailure: false,
-                    target: settle_call.target(),
-                    callData: settle_call.calldata().clone(),
+                    target: settle_target,
+                    callData: settle_calldata.clone(),
                 };
                 let aggregate_call = IMulticall3::aggregate3Call {
                     calls: vec![deployment_call, transfer_with_authorization_call],
@@ -441,20 +699,38 @@ where
             }
         }
         StructuredSignature::EOA(signature) => {
-            let settle_call = exact_permit2_proxy.settle(
-                permit_transfer_from,
-                payer,
-                witness,
-                signature.as_bytes().into(),
-            );
-            let tx_fut = Eip155MetaTransactionProvider::send_transaction(
-                provider,
-                MetaTransaction {
-                    to: settle_call.target(),
-                    calldata: settle_call.calldata().clone(),
-                    confirmations: 1,
-                },
-            );
+            let tx_fut = if let Some(permit2612) = eip2612_permit.clone() {
+                let settle_call = exact_permit2_proxy.settleWithPermit(
+                    permit2612,
+                    permit_transfer_from,
+                    payer,
+                    witness,
+                    signature.as_bytes().into(),
+                );
+                Eip155MetaTransactionProvider::send_transaction(
+                    provider,
+                    MetaTransaction {
+                        to: settle_call.target(),
+                        calldata: settle_call.calldata().clone(),
+                        confirmations: 1,
+                    },
+                )
+            } else {
+                let settle_call = exact_permit2_proxy.settle(
+                    permit_transfer_from,
+                    payer,
+                    witness,
+                    signature.as_bytes().into(),
+                );
+                Eip155MetaTransactionProvider::send_transaction(
+                    provider,
+                    MetaTransaction {
+                        to: settle_call.target(),
+                        calldata: settle_call.calldata().clone(),
+                        confirmations: 1,
+                    },
+                )
+            };
             #[cfg(feature = "telemetry")]
             let receipt = tx_fut
                 .instrument(tracing::info_span!("call_exact_permit2_proxy_settle.EOA",
@@ -475,16 +751,34 @@ where
             receipt
         }
         StructuredSignature::EIP1271(signature) => {
-            let settle_call =
-                exact_permit2_proxy.settle(permit_transfer_from, payer, witness, signature.clone());
-            let tx_fut = Eip155MetaTransactionProvider::send_transaction(
-                provider,
-                MetaTransaction {
-                    to: settle_call.target(),
-                    calldata: settle_call.calldata().clone(),
-                    confirmations: 1,
-                },
-            );
+            let tx_fut = if let Some(permit2612) = eip2612_permit {
+                let settle_call = exact_permit2_proxy.settleWithPermit(
+                    permit2612,
+                    permit_transfer_from,
+                    payer,
+                    witness,
+                    signature.clone(),
+                );
+                Eip155MetaTransactionProvider::send_transaction(
+                    provider,
+                    MetaTransaction {
+                        to: settle_call.target(),
+                        calldata: settle_call.calldata().clone(),
+                        confirmations: 1,
+                    },
+                )
+            } else {
+                let settle_call =
+                    exact_permit2_proxy.settle(permit_transfer_from, payer, witness, signature.clone());
+                Eip155MetaTransactionProvider::send_transaction(
+                    provider,
+                    MetaTransaction {
+                        to: settle_call.target(),
+                        calldata: settle_call.calldata().clone(),
+                        confirmations: 1,
+                    },
+                )
+            };
             #[cfg(feature = "telemetry")]
             let receipt = tx_fut
                 .instrument(
@@ -508,4 +802,99 @@ where
         }
     };
     tx_hash_from_receipt(&receipt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        EXTENSION_EIP2612_GAS_SPONSORING, Eip2612GasSponsoringInfo,
+        extract_eip2612_gas_sponsoring_info, validate_eip2612_gas_sponsoring_info,
+    };
+    use alloy_primitives::{Bytes, U256};
+    use std::collections::HashMap;
+    use x402_types::proto::PaymentVerificationError;
+    use x402_types::timestamp::UnixTimestamp;
+
+    use crate::chain::permit2::PERMIT2_ADDRESS;
+    use crate::v2_eip155_exact::types::Permit2PaymentPayload;
+
+    fn sample_payment_payload() -> Permit2PaymentPayload {
+        serde_json::from_value(serde_json::json!({
+            "x402Version": 2,
+            "accepted": {
+                "scheme": "exact",
+                "network": "eip155:1",
+                "amount": "1000000000000000000",
+                "payTo": "0x1111111111111111111111111111111111111111",
+                "maxTimeoutSeconds": 60,
+                "asset": "0x2222222222222222222222222222222222222222",
+                "extra": { "assetTransferMethod": "permit2" }
+            },
+            "payload": {
+                "permit2Authorization": {
+                    "deadline": "4294967295",
+                    "from": "0x3333333333333333333333333333333333333333",
+                    "nonce": "1",
+                    "permitted": {
+                        "amount": "1000000000000000000",
+                        "token": "0x2222222222222222222222222222222222222222"
+                    },
+                    "spender": "0x4020615294c913F045dc10f0a5cdEbd86c280001",
+                    "witness": {
+                        "extra": "0x",
+                        "to": "0x1111111111111111111111111111111111111111",
+                        "validAfter": "0"
+                    }
+                },
+                "signature": "0x111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111b"
+            },
+            "extensions": {}
+        }))
+        .expect("valid permit2 payload")
+    }
+
+    #[test]
+    fn extracts_wrapped_eip2612_extension_info() {
+        let mut extensions = HashMap::new();
+        extensions.insert(
+            EXTENSION_EIP2612_GAS_SPONSORING.to_string(),
+            serde_json::json!({
+                "info": {
+                    "from": "0x3333333333333333333333333333333333333333",
+                    "asset": "0x2222222222222222222222222222222222222222",
+                    "spender": format!("{PERMIT2_ADDRESS:#x}"),
+                    "amount": "1000000000000000000",
+                    "nonce": "0",
+                    "deadline": "4294967295",
+                    "signature": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1b",
+                    "version": "1"
+                }
+            }),
+        );
+
+        let info = extract_eip2612_gas_sponsoring_info(&extensions)
+            .expect("valid extension")
+            .expect("extension present");
+        assert_eq!(info.amount, U256::from(1_000_000_000_000_000_000u128));
+        assert_eq!(info.spender.0, PERMIT2_ADDRESS);
+    }
+
+    #[test]
+    fn rejects_mismatched_eip2612_amount() {
+        let payment_payload = sample_payment_payload();
+        let info = Eip2612GasSponsoringInfo {
+            from: payment_payload.payload.permit_2_authorization.from,
+            asset: payment_payload.accepted.asset,
+            spender: PERMIT2_ADDRESS.into(),
+            amount: U256::from(2u64),
+            _nonce: U256::ZERO,
+            deadline: UnixTimestamp::from_secs(4_294_967_295),
+            signature: Bytes::from_static(&[0x11; 65]),
+            version: "1".to_string(),
+        };
+
+        let err = validate_eip2612_gas_sponsoring_info(&info, &payment_payload)
+            .expect_err("amount mismatch should fail");
+        assert!(matches!(err, PaymentVerificationError::InvalidPaymentAmount));
+    }
 }

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_upto/client.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_upto/client.rs
@@ -246,6 +246,7 @@ where
         let payload = v2::PaymentPayload {
             x402_version: v2::X402Version2,
             accepted: self.requirements_json.clone(),
+            extensions: Default::default(),
             resource: self.resource_info.clone(),
             payload: permit2_payload,
         };

--- a/crates/chains/x402-chain-solana/src/chain/config.rs
+++ b/crates/chains/x402-chain-solana/src/chain/config.rs
@@ -62,7 +62,7 @@ impl SolanaChainConfig {
 
     /// Returns the optional WebSocket pubsub endpoint URL.
     pub fn pubsub(&self) -> Option<&Url> {
-        self.inner.pubsub.as_ref().map(|u| u.deref())
+        self.inner.pubsub.as_deref()
     }
 }
 

--- a/crates/chains/x402-chain-solana/src/chain/provider.rs
+++ b/crates/chains/x402-chain-solana/src/chain/provider.rs
@@ -207,7 +207,7 @@ impl SolanaChainProvider {
 impl FromConfig<SolanaChainConfig> for SolanaChainProvider {
     async fn from_config(config: &SolanaChainConfig) -> Result<Self, Box<dyn std::error::Error>> {
         let rpc_url = config.rpc();
-        let pubsub_url = config.pubsub().clone().map(|url| url.to_string());
+        let pubsub_url = config.pubsub().map(|url| url.to_string());
         let keypair = Keypair::from_base58_string(&config.signer().to_string());
         let max_compute_unit_limit = config.max_compute_unit_limit();
         let max_compute_unit_price = config.max_compute_unit_price();

--- a/crates/chains/x402-chain-solana/src/v2_solana_exact/client.rs
+++ b/crates/chains/x402-chain-solana/src/v2_solana_exact/client.rs
@@ -137,6 +137,7 @@ impl<S: Signer + Sync, R: RpcClientLike + Sync> PaymentCandidateSigner for Paylo
         let payload = PaymentPayload {
             x402_version: X402Version2,
             accepted: self.requirements_json.clone(),
+            extensions: Default::default(),
             resource: Some(self.resource.clone()),
             payload: ExactSolanaPayload {
                 transaction: tx_b64,

--- a/crates/x402-axum/src/paygate.rs
+++ b/crates/x402-axum/src/paygate.rs
@@ -55,7 +55,7 @@ use x402_types::util::Base64Bytes;
 // ============================================================================
 
 /// Builder for resource information that can be used with both V1 and V2 protocols.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ResourceInfoBuilder {
     /// Description of the protected resource
     pub description: Option<String>,
@@ -63,16 +63,6 @@ pub struct ResourceInfoBuilder {
     pub mime_type: Option<String>,
     /// Optional explicit URL of the protected resource
     pub url: Option<String>,
-}
-
-impl Default for ResourceInfoBuilder {
-    fn default() -> Self {
-        Self {
-            description: None,
-            mime_type: None,
-            url: None,
-        }
-    }
 }
 
 impl ResourceInfoBuilder {

--- a/crates/x402-axum/src/paygate.rs
+++ b/crates/x402-axum/src/paygate.rs
@@ -347,6 +347,7 @@ impl PaygateProtocol for v2::PriceTag {
                 let payment_required_response = v2::PaymentRequired {
                     error: Some(err.to_string()),
                     accepts: accepts.iter().map(|pt| pt.requirements.clone()).collect(),
+                    extensions: Default::default(),
                     x402_version: v2::X402Version2,
                     resource: resource.clone(),
                 };

--- a/crates/x402-facilitator-local/Cargo.toml
+++ b/crates/x402-facilitator-local/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { workspace = true, features = ["signal"] }
 tokio-util = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }
+prometheus = { workspace = true }
 
 # Tracing and OpenTelemetry (optional, enabled via `telemetry` feature)
 tracing = { workspace = true, optional = true }

--- a/crates/x402-facilitator-local/src/facilitator_local.rs
+++ b/crates/x402-facilitator-local/src/facilitator_local.rs
@@ -124,11 +124,17 @@ impl Facilitator for FacilitatorLocal<SchemeRegistry> {
 
     async fn supported(&self) -> Result<proto::SupportedResponse, Self::Error> {
         let mut kinds = vec![];
+        let mut extensions = vec![];
         let mut signers = HashMap::new();
         for provider in self.handlers.values() {
             let supported = provider.supported().await.ok();
             if let Some(mut supported) = supported {
                 kinds.append(&mut supported.kinds);
+                for extension in supported.extensions {
+                    if !extensions.contains(&extension) {
+                        extensions.push(extension);
+                    }
+                }
                 for (chain_id, signer_addresses) in supported.signers {
                     signers.entry(chain_id).or_insert(signer_addresses);
                 }
@@ -136,7 +142,7 @@ impl Facilitator for FacilitatorLocal<SchemeRegistry> {
         }
         Ok(proto::SupportedResponse {
             kinds,
-            extensions: Vec::new(),
+            extensions,
             signers,
         })
     }

--- a/crates/x402-facilitator-local/src/handlers.rs
+++ b/crates/x402-facilitator-local/src/handlers.rs
@@ -16,6 +16,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router, response::IntoResponse};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::time::Instant;
 use x402_types::facilitator::Facilitator;
 use x402_types::proto;
 use x402_types::proto::{AsPaymentProblem, ErrorReason, PaymentVerificationError};
@@ -25,6 +26,7 @@ use x402_types::scheme::X402SchemeFacilitatorError;
 use tracing::instrument;
 
 use crate::facilitator_local::FacilitatorLocalError;
+use crate::metrics;
 
 /// `GET /verify`: Returns a machine-readable description of the `/verify` endpoint.
 ///
@@ -101,6 +103,7 @@ where
         .route("/settle", post(post_settle::<A>))
         .route("/health", get(get_health::<A>))
         .route("/supported", get(get_supported::<A>))
+        .route("/metrics", get(metrics::get_metrics))
 }
 
 /// `GET /`: Returns a simple greeting message from the facilitator.
@@ -161,8 +164,17 @@ where
     A: Facilitator,
     A::Error: IntoResponse,
 {
-    match facilitator.verify(&body).await {
-        Ok(valid_response) => (StatusCode::OK, Json(valid_response)).into_response(),
+    let (scheme, chain) = extract_labels(&body);
+
+    let start = Instant::now();
+    let result = facilitator.verify(&body).await;
+    let duration = start.elapsed().as_secs_f64();
+
+    match result {
+        Ok(valid_response) => {
+            metrics::record_verify("ok", &scheme, &chain, duration);
+            (StatusCode::OK, Json(valid_response)).into_response()
+        }
         Err(error) => {
             #[cfg(feature = "telemetry")]
             tracing::warn!(
@@ -170,7 +182,9 @@ where
                 body = %serde_json::to_string(&body).unwrap_or_else(|_| "<can-not-serialize>".to_string()),
                 "Verification failed"
             );
-            error.into_response()
+            let response = error.into_response();
+            metrics::record_verify(status_label(response.status()), &scheme, &chain, duration);
+            response
         }
     }
 }
@@ -196,8 +210,17 @@ where
     A: Facilitator,
     A::Error: IntoResponse,
 {
-    match facilitator.settle(&body).await {
-        Ok(valid_response) => (StatusCode::OK, Json(valid_response)).into_response(),
+    let (scheme, chain) = extract_labels(&body);
+
+    let start = Instant::now();
+    let result = facilitator.settle(&body).await;
+    let duration = start.elapsed().as_secs_f64();
+
+    match result {
+        Ok(valid_response) => {
+            metrics::record_settle("ok", &scheme, &chain, duration);
+            (StatusCode::OK, Json(valid_response)).into_response()
+        }
         Err(error) => {
             #[cfg(feature = "telemetry")]
             tracing::warn!(
@@ -205,8 +228,38 @@ where
                 body = %serde_json::to_string(&body).unwrap_or_else(|_| "<can-not-serialize>".to_string()),
                 "Settlement failed"
             );
-            error.into_response()
+            let response = error.into_response();
+            metrics::record_settle(status_label(response.status()), &scheme, &chain, duration);
+            response
         }
+    }
+}
+
+/// Extract scheme and chain labels from a request body.
+///
+/// Returns `("unknown", "unknown")` for requests that cannot be parsed into a
+/// valid [`SchemeHandlerSlug`](x402_types::scheme::SchemeHandlerSlug). This
+/// bounds label cardinality to the set of configured schemes + one "unknown"
+/// fallback per dimension.
+fn extract_labels(body: &proto::VerifyRequest) -> (String, String) {
+    body.scheme_handler_slug()
+        .map(|s| (s.name, s.chain_id.to_string()))
+        .unwrap_or_else(|| ("unknown".into(), "unknown".into()))
+}
+
+/// Map an HTTP status code to a metrics label.
+///
+/// Groups responses into `client_error` (4xx) and `server_error` (5xx) so
+/// operators can separate retriable failures from client-side issues in their
+/// dashboards. Works with any `Facilitator` implementation, not just
+/// `FacilitatorLocal`.
+fn status_label(status: StatusCode) -> &'static str {
+    if status.is_client_error() {
+        "client_error"
+    } else if status.is_server_error() {
+        "server_error"
+    } else {
+        "unknown_error"
     }
 }
 

--- a/crates/x402-facilitator-local/src/lib.rs
+++ b/crates/x402-facilitator-local/src/lib.rs
@@ -63,6 +63,7 @@
 
 pub mod facilitator_local;
 pub mod handlers;
+pub mod metrics;
 pub mod util;
 
 pub use facilitator_local::*;

--- a/crates/x402-facilitator-local/src/metrics.rs
+++ b/crates/x402-facilitator-local/src/metrics.rs
@@ -1,0 +1,214 @@
+//! Prometheus metrics for the x402 facilitator.
+//!
+//! Exposes request counters and latency histograms for payment verification and
+//! settlement operations. All metrics are served at `GET /metrics` in Prometheus
+//! text exposition format.
+//!
+//! # Label safety
+//!
+//! The `scheme` and `chain` labels are bounded by the facilitator's configured
+//! scheme registry — only values that pass [`SchemeHandlerSlug`] parsing from a
+//! valid request body are recorded. Requests with unparseable payloads are
+//! recorded with `scheme="unknown"` and `chain="unknown"`, preventing unbounded
+//! label cardinality from malicious input.
+
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use prometheus::{
+    Encoder, HistogramOpts, HistogramVec, IntCounterVec, Opts, Registry, TextEncoder,
+};
+use std::sync::LazyLock;
+
+/// Isolated Prometheus registry for facilitator metrics.
+///
+/// Uses a dedicated registry (not the global default) to avoid naming conflicts
+/// when the facilitator is embedded alongside other instrumented components.
+static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
+
+/// Total verify requests, labelled by outcome, scheme, and chain.
+///
+/// The `status` label uses one of: `ok`, `client_error` (HTTP 400/412),
+/// `server_error` (HTTP 500), or `invalid_request` (unparseable body).
+static VERIFY_REQUESTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let opts = Opts::new(
+        "x402_facilitator_verify_requests_total",
+        "Total payment verification requests",
+    );
+    let counter = IntCounterVec::new(opts, &["status", "scheme", "chain"])
+        .expect("failed to create verify_requests metric");
+    REGISTRY
+        .register(Box::new(counter.clone()))
+        .expect("failed to register verify_requests metric");
+    counter
+});
+
+/// Total settle requests, labelled by outcome, scheme, and chain.
+static SETTLE_REQUESTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let opts = Opts::new(
+        "x402_facilitator_settle_requests_total",
+        "Total payment settlement requests",
+    );
+    let counter = IntCounterVec::new(opts, &["status", "scheme", "chain"])
+        .expect("failed to create settle_requests metric");
+    REGISTRY
+        .register(Box::new(counter.clone()))
+        .expect("failed to register settle_requests metric");
+    counter
+});
+
+/// Verify request duration in seconds.
+static VERIFY_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
+    let opts = HistogramOpts::new(
+        "x402_facilitator_verify_duration_seconds",
+        "Payment verification latency in seconds",
+    )
+    .buckets(vec![
+        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+    ]);
+    let histogram = HistogramVec::new(opts, &["scheme", "chain"])
+        .expect("failed to create verify_duration metric");
+    REGISTRY
+        .register(Box::new(histogram.clone()))
+        .expect("failed to register verify_duration metric");
+    histogram
+});
+
+/// Settle request duration in seconds.
+static SETTLE_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
+    let opts = HistogramOpts::new(
+        "x402_facilitator_settle_duration_seconds",
+        "Payment settlement latency in seconds",
+    )
+    .buckets(vec![
+        0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+    ]);
+    let histogram = HistogramVec::new(opts, &["scheme", "chain"])
+        .expect("failed to create settle_duration metric");
+    REGISTRY
+        .register(Box::new(histogram.clone()))
+        .expect("failed to register settle_duration metric");
+    histogram
+});
+
+/// Record a verify request with its outcome, labels, and duration.
+pub fn record_verify(status: &str, scheme: &str, chain: &str, duration_secs: f64) {
+    VERIFY_REQUESTS
+        .with_label_values(&[status, scheme, chain])
+        .inc();
+    VERIFY_DURATION
+        .with_label_values(&[scheme, chain])
+        .observe(duration_secs);
+}
+
+/// Record a settle request with its outcome, labels, and duration.
+pub fn record_settle(status: &str, scheme: &str, chain: &str, duration_secs: f64) {
+    SETTLE_REQUESTS
+        .with_label_values(&[status, scheme, chain])
+        .inc();
+    SETTLE_DURATION
+        .with_label_values(&[scheme, chain])
+        .observe(duration_secs);
+}
+
+/// `GET /metrics`: Prometheus text exposition endpoint.
+pub async fn get_metrics() -> impl IntoResponse {
+    // Force lazy initialization so metrics appear even before the first request.
+    let _ = &*VERIFY_REQUESTS;
+    let _ = &*SETTLE_REQUESTS;
+    let _ = &*VERIFY_DURATION;
+    let _ = &*SETTLE_DURATION;
+
+    let encoder = TextEncoder::new();
+    let metric_families = REGISTRY.gather();
+    let mut buffer = Vec::new();
+    match encoder.encode(&metric_families, &mut buffer) {
+        Ok(()) => (
+            StatusCode::OK,
+            [(axum::http::header::CONTENT_TYPE, encoder.format_type())],
+            buffer,
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("metrics encoding error: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_record_verify_increments_counter() {
+        record_verify("ok", "exact", "eip155:8453", 0.042);
+        record_verify("client_error", "exact", "eip155:8453", 0.003);
+
+        let families = REGISTRY.gather();
+        let verify_family = families
+            .iter()
+            .find(|f| f.get_name() == "x402_facilitator_verify_requests_total")
+            .expect("verify counter not found");
+
+        let total: f64 = verify_family
+            .get_metric()
+            .iter()
+            .map(|m| m.get_counter().get_value())
+            .sum();
+        assert!(total >= 2.0, "expected at least 2 verify requests, got {total}");
+    }
+
+    #[test]
+    fn test_record_settle_increments_counter() {
+        record_settle("ok", "exact", "eip155:8453", 1.5);
+        record_settle("server_error", "exact", "eip155:8453", 0.8);
+
+        let families = REGISTRY.gather();
+        let settle_family = families
+            .iter()
+            .find(|f| f.get_name() == "x402_facilitator_settle_requests_total")
+            .expect("settle counter not found");
+
+        let total: f64 = settle_family
+            .get_metric()
+            .iter()
+            .map(|m| m.get_counter().get_value())
+            .sum();
+        assert!(total >= 2.0, "expected at least 2 settle requests, got {total}");
+    }
+
+    #[tokio::test]
+    async fn test_metrics_endpoint_returns_valid_prometheus_format() {
+        // Record something so metrics are non-empty.
+        record_verify("ok", "exact", "eip155:84532", 0.01);
+
+        let response = get_metrics().await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(
+            text.contains("x402_facilitator_verify_requests_total"),
+            "missing verify counter in output"
+        );
+        assert!(
+            text.contains("x402_facilitator_verify_duration_seconds"),
+            "missing verify histogram in output"
+        );
+        assert!(
+            text.contains("x402_facilitator_settle_requests_total"),
+            "missing settle counter in output"
+        );
+    }
+
+    #[test]
+    fn test_unknown_scheme_chain_does_not_panic() {
+        // Simulates an unparseable request — should not panic.
+        record_verify("invalid_request", "unknown", "unknown", 0.001);
+        record_settle("invalid_request", "unknown", "unknown", 0.001);
+    }
+}

--- a/crates/x402-types/src/proto/v2.rs
+++ b/crates/x402-types/src/proto/v2.rs
@@ -22,6 +22,7 @@
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
@@ -182,6 +183,9 @@ pub struct PaymentPayload<TPaymentRequirements, TPayload> {
     pub accepted: TPaymentRequirements,
     /// The scheme-specific signed payload.
     pub payload: TPayload,
+    /// Optional protocol extensions echoed and enriched by the client.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub extensions: HashMap<String, serde_json::Value>,
     /// Information about the resource being paid for.
     pub resource: Option<ResourceInfo>,
     /// Protocol version (always 2).
@@ -256,6 +260,9 @@ pub struct PaymentRequired<TAccepts = PaymentRequirements> {
     /// List of acceptable payment methods.
     #[serde(default = "Vec::default")]
     pub accepts: Vec<TAccepts>,
+    /// Optional protocol extensions supported by the server/facilitator.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub extensions: HashMap<String, serde_json::Value>,
 }
 
 /// Builder for creating V2 payment requirements.


### PR DESCRIPTION
## Summary
- add V2 payload/402 response extension fields in the shared protocol types
- union supported extensions in the local facilitator `/supported` response
- add exact EVM facilitator config for `supportedExtensions`
- make exact EVM Permit2 verify/settle extension-aware for `eip2612GasSponsoring`
- add focused unit tests for extension parsing and validation

## Notes
- this is aimed at Ethereum mainnet OBOL via Permit2 with EIP-2612 gas sponsoring
- a companion infra PR prepares Obol's hosted facilitator chart for `eip155:1` and `supportedExtensions: ["eip2612GasSponsoring"]`
