### PR TITLE
Add EIP-155 batch settlement facilitator

### DIFF
--- a/crates/chains/x402-chain-eip155/src/chain/types.rs
+++ b/crates/chains/x402-chain-eip155/src/chain/types.rs
@@ -89,6 +89,34 @@ impl AsRef<Address> for ChecksummedAddress {
     }
 }
 
+/// Serde helper that marshals a `U128` as a decimal string.
+///
+/// `alloy_primitives::U128`'s default `Serialize` impl emits an `0x`-prefixed hex
+/// string. The x402 wire format expects decimal strings — required for parity
+/// with the TypeScript and Go reference implementations that drive the `batch-settlement`
+/// channel snapshots.
+pub mod decimal_u128 {
+    use alloy_primitives::U128;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    /// Serialize a `U128` as a decimal string.
+    pub fn serialize<S>(value: &U128, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&value.to_string())
+    }
+
+    /// Deserialize a decimal string into a `U128`.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<U128, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        U128::from_str_radix(&s, 10).map_err(serde::de::Error::custom)
+    }
+}
+
 /// The CAIP-2 namespace for EVM-compatible chains.
 pub const EIP155_NAMESPACE: &str = "eip155";
 

--- a/crates/chains/x402-chain-eip155/src/lib.rs
+++ b/crates/chains/x402-chain-eip155/src/lib.rs
@@ -77,6 +77,7 @@
 
 pub mod chain;
 pub mod v1_eip155_exact;
+pub mod v2_eip155_batch_settlement;
 pub mod v2_eip155_exact;
 pub mod v2_eip155_upto;
 
@@ -86,6 +87,7 @@ mod networks;
 pub use networks::*;
 
 pub use v1_eip155_exact::V1Eip155Exact;
+pub use v2_eip155_batch_settlement::V2Eip155BatchSettlement;
 pub use v2_eip155_exact::V2Eip155Exact;
 pub use v2_eip155_upto::V2Eip155Upto;
 
@@ -96,4 +98,5 @@ pub use v2_eip155_exact::client::V2Eip155ExactClient;
 #[cfg(feature = "client")]
 pub use v2_eip155_upto::client::V2Eip155UptoClient;
 
+pub use chain::types::decimal_u128;
 pub use x402_types::util::decimal_u256;

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/constants.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/constants.rs
@@ -1,0 +1,67 @@
+//! Canonical addresses, EIP-712 type hashes, and protocol bounds for the
+//! `batch-settlement` EVM scheme.
+//!
+//! These mirror `typescript/packages/mechanisms/evm/src/batch-settlement/constants.ts`
+//! exactly. The `x402BatchSettlement`, `ERC3009DepositCollector`, and
+//! `Permit2DepositCollector` contracts are deployed via CREATE2 at the same
+//! addresses across every supported EVM chain.
+
+use alloy_primitives::{Address, address};
+
+/// Scheme identifier for the batch-settlement payment scheme.
+pub const BATCH_SETTLEMENT_SCHEME: &str = "batch-settlement";
+
+/// Deployed address of the `x402BatchSettlement` contract.
+pub const BATCH_SETTLEMENT_ADDRESS: Address =
+    address!("0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003");
+
+/// Deployed address of the `ERC3009DepositCollector` contract.
+pub const ERC3009_DEPOSIT_COLLECTOR_ADDRESS: Address =
+    address!("0x4020806089470a89826cB9fB1f4059150b550004");
+
+/// Deployed address of the `Permit2DepositCollector` contract.
+pub const PERMIT2_DEPOSIT_COLLECTOR_ADDRESS: Address =
+    address!("0x4020425FAf3B746C082C2f942b4E5159887B0005");
+
+/// Minimum withdraw delay in seconds (15 minutes), matching the onchain constant.
+pub const MIN_WITHDRAW_DELAY: u64 = 900;
+
+/// Maximum withdraw delay in seconds (30 days), matching the onchain constant.
+pub const MAX_WITHDRAW_DELAY: u64 = 2_592_000;
+
+/// EIP-712 domain name shared across all batch-settlement typed-data signatures.
+pub const BATCH_SETTLEMENT_DOMAIN_NAME: &str = "x402 Batch Settlement";
+
+/// EIP-712 domain version shared across all batch-settlement typed-data signatures.
+pub const BATCH_SETTLEMENT_DOMAIN_VERSION: &str = "1";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_addresses_match_spec() {
+        // Sanity checks that the canonical addresses literally match the spec.
+        // These addresses are referenced by the deployed contracts and must be
+        // identical across every EVM chain — drift would break interop with
+        // every other batch-settlement implementation.
+        assert_eq!(
+            format!("{:#x}", BATCH_SETTLEMENT_ADDRESS),
+            "0x4020074e9df2ce1dee5a9c1b5c3f541d02a10003"
+        );
+        assert_eq!(
+            format!("{:#x}", ERC3009_DEPOSIT_COLLECTOR_ADDRESS),
+            "0x4020806089470a89826cb9fb1f4059150b550004"
+        );
+        assert_eq!(
+            format!("{:#x}", PERMIT2_DEPOSIT_COLLECTOR_ADDRESS),
+            "0x4020425faf3b746c082c2f942b4e5159887b0005"
+        );
+    }
+
+    #[test]
+    fn withdraw_delay_bounds_match_spec() {
+        assert_eq!(MIN_WITHDRAW_DELAY, 15 * 60);
+        assert_eq!(MAX_WITHDRAW_DELAY, 30 * 24 * 60 * 60);
+    }
+}

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/encoding.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/encoding.rs
@@ -64,13 +64,18 @@ pub fn build_erc3009_collector_data(
     salt: B256,
     signature: &Bytes,
 ) -> Bytes {
-    let data = Erc3009CollectorData {
-        validAfter: valid_after,
-        validBefore: valid_before,
-        salt: U256::from_be_bytes(salt.0),
-        signature: signature.clone(),
-    };
-    Bytes::from(data.abi_encode())
+    // The x402 collector contract decodes this as
+    // `(uint256,uint256,uint256,bytes)`, so encode a parameter sequence rather
+    // than a single wrapped struct value.
+    Bytes::from(
+        (
+            valid_after,
+            valid_before,
+            U256::from_be_bytes(salt.0),
+            signature.clone(),
+        )
+            .abi_encode_sequence(),
+    )
 }
 
 /// Encodes optional EIP-2612 permit data consumed by `Permit2DepositCollector`.
@@ -95,13 +100,18 @@ pub fn build_permit2_collector_data(
     permit2_signature: &Bytes,
     eip2612_permit_data: &Bytes,
 ) -> Bytes {
-    let data = Permit2CollectorData {
-        nonce,
-        deadline,
-        permit2Signature: permit2_signature.clone(),
-        eip2612PermitData: eip2612_permit_data.clone(),
-    };
-    Bytes::from(data.abi_encode())
+    // The x402 collector contract decodes this as
+    // `(uint256,uint256,bytes,bytes)`, so encode a parameter sequence rather
+    // than a single wrapped struct value.
+    Bytes::from(
+        (
+            nonce,
+            deadline,
+            permit2_signature.clone(),
+            eip2612_permit_data.clone(),
+        )
+            .abi_encode_sequence(),
+    )
 }
 
 #[cfg(test)]
@@ -133,7 +143,8 @@ mod tests {
             b256!("0x0000000000000000000000000000000000000000000000000000000000000077"),
             &Bytes::from_static(&hex!("deadbeef")),
         );
-        let decoded = Erc3009CollectorData::abi_decode(&bytes).unwrap();
+        assert_eq!(bytes.len(), 192);
+        let decoded = Erc3009CollectorData::abi_decode_sequence(&bytes).unwrap();
         assert_eq!(decoded.validAfter, U256::ZERO);
         assert_eq!(decoded.validBefore, U256::from(1_770_000_000u64));
         assert_eq!(decoded.salt, U256::from(0x77u64));
@@ -148,7 +159,8 @@ mod tests {
             &Bytes::from_static(&hex!("abcd")),
             &Bytes::new(),
         );
-        let decoded = Permit2CollectorData::abi_decode(&bytes).unwrap();
+        assert_eq!(bytes.len(), 224);
+        let decoded = Permit2CollectorData::abi_decode_sequence(&bytes).unwrap();
         assert_eq!(decoded.nonce, U256::from(42u64));
         assert_eq!(decoded.deadline, U256::from(1_770_000_000u64));
         assert_eq!(decoded.permit2Signature, Bytes::from_static(&hex!("abcd")));

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/encoding.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/encoding.rs
@@ -1,0 +1,172 @@
+//! Calldata-encoding helpers for the batch-settlement deposit collectors.
+//!
+//! Mirrors `typescript/packages/mechanisms/evm/src/batch-settlement/encoding.ts`
+//! exactly. The `x402BatchSettlement.deposit(...)` entry point takes an
+//! opaque `bytes collectorData`; the shape of those bytes depends on which
+//! deposit collector contract is being targeted.
+
+use alloy_primitives::{B256, Bytes, U256, keccak256};
+use alloy_sol_types::{SolValue, sol};
+
+sol! {
+    /// `keccak256(abi.encode(channelId, salt))` — the ERC-3009 nonce that binds
+    /// a deposit authorization to a specific channel + per-deposit salt.
+    struct Erc3009DepositNonceInput {
+        bytes32 channelId;
+        uint256 salt;
+    }
+
+    /// `abi.encode(validAfter, validBefore, salt, signature)` — the
+    /// `collectorData` payload for `ERC3009DepositCollector.collect(...)`.
+    struct Erc3009CollectorData {
+        uint256 validAfter;
+        uint256 validBefore;
+        uint256 salt;
+        bytes signature;
+    }
+
+    /// `abi.encode(value, deadline, v, r, s)` — the optional EIP-2612 permit
+    /// segment consumed by `Permit2DepositCollector` for atomic approvals.
+    struct Eip2612PermitData {
+        uint256 value;
+        uint256 deadline;
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+    }
+
+    /// `abi.encode(nonce, deadline, permit2Signature, eip2612PermitData)` — the
+    /// `collectorData` payload for `Permit2DepositCollector.collect(...)`.
+    /// `eip2612PermitData` is `0x` when no EIP-2612 permit is bundled.
+    struct Permit2CollectorData {
+        uint256 nonce;
+        uint256 deadline;
+        bytes permit2Signature;
+        bytes eip2612PermitData;
+    }
+}
+
+/// Computes the ERC-3009 nonce used by the deposit collector:
+/// `keccak256(abi.encode(channelId, salt))`.
+pub fn build_erc3009_deposit_nonce(channel_id: B256, salt: B256) -> B256 {
+    let input = Erc3009DepositNonceInput {
+        channelId: channel_id,
+        salt: U256::from_be_bytes(salt.0),
+    };
+    keccak256(input.abi_encode())
+}
+
+/// Encodes the `collectorData` payload for `ERC3009DepositCollector.collect()`:
+/// `abi.encode(validAfter, validBefore, salt, signature)`.
+pub fn build_erc3009_collector_data(
+    valid_after: U256,
+    valid_before: U256,
+    salt: B256,
+    signature: &Bytes,
+) -> Bytes {
+    let data = Erc3009CollectorData {
+        validAfter: valid_after,
+        validBefore: valid_before,
+        salt: U256::from_be_bytes(salt.0),
+        signature: signature.clone(),
+    };
+    Bytes::from(data.abi_encode())
+}
+
+/// Encodes optional EIP-2612 permit data consumed by `Permit2DepositCollector`.
+pub fn build_eip2612_permit_data(value: U256, deadline: U256, v: u8, r: B256, s: B256) -> Bytes {
+    let data = Eip2612PermitData {
+        value,
+        deadline,
+        v,
+        r,
+        s,
+    };
+    Bytes::from(data.abi_encode())
+}
+
+/// Encodes the `collectorData` payload for `Permit2DepositCollector.collect()`.
+///
+/// Pass an empty `eip2612_permit_data` (`Bytes::new()`) when no EIP-2612
+/// permit is bundled — the contract treats `0x` as "no permit".
+pub fn build_permit2_collector_data(
+    nonce: U256,
+    deadline: U256,
+    permit2_signature: &Bytes,
+    eip2612_permit_data: &Bytes,
+) -> Bytes {
+    let data = Permit2CollectorData {
+        nonce,
+        deadline,
+        permit2Signature: permit2_signature.clone(),
+        eip2612PermitData: eip2612_permit_data.clone(),
+    };
+    Bytes::from(data.abi_encode())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{b256, hex};
+
+    #[test]
+    fn erc3009_deposit_nonce_matches_keccak_of_abi_encoded_pair() {
+        // Independently compute the expected nonce by hashing the manually
+        // constructed `abi.encode(bytes32, uint256)` payload: two 32-byte
+        // big-endian words.
+        let channel_id =
+            b256!("0x1111111111111111111111111111111111111111111111111111111111111111");
+        let salt = b256!("0x2222222222222222222222222222222222222222222222222222222222222222");
+        let mut packed = [0u8; 64];
+        packed[..32].copy_from_slice(channel_id.as_slice());
+        packed[32..].copy_from_slice(salt.as_slice());
+        let expected = keccak256(packed);
+
+        assert_eq!(build_erc3009_deposit_nonce(channel_id, salt), expected);
+    }
+
+    #[test]
+    fn erc3009_collector_data_round_trips_via_abi() {
+        let bytes = build_erc3009_collector_data(
+            U256::from(0u64),
+            U256::from(1_770_000_000u64),
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000077"),
+            &Bytes::from_static(&hex!("deadbeef")),
+        );
+        let decoded = Erc3009CollectorData::abi_decode(&bytes).unwrap();
+        assert_eq!(decoded.validAfter, U256::ZERO);
+        assert_eq!(decoded.validBefore, U256::from(1_770_000_000u64));
+        assert_eq!(decoded.salt, U256::from(0x77u64));
+        assert_eq!(decoded.signature, Bytes::from_static(&hex!("deadbeef")));
+    }
+
+    #[test]
+    fn permit2_collector_data_round_trips_via_abi() {
+        let bytes = build_permit2_collector_data(
+            U256::from(42u64),
+            U256::from(1_770_000_000u64),
+            &Bytes::from_static(&hex!("abcd")),
+            &Bytes::new(),
+        );
+        let decoded = Permit2CollectorData::abi_decode(&bytes).unwrap();
+        assert_eq!(decoded.nonce, U256::from(42u64));
+        assert_eq!(decoded.deadline, U256::from(1_770_000_000u64));
+        assert_eq!(decoded.permit2Signature, Bytes::from_static(&hex!("abcd")));
+        assert_eq!(decoded.eip2612PermitData, Bytes::new());
+    }
+
+    #[test]
+    fn eip2612_permit_data_round_trips_via_abi() {
+        let bytes = build_eip2612_permit_data(
+            U256::from(1_000u64),
+            U256::from(1_770_000_000u64),
+            27,
+            b256!("0x1111111111111111111111111111111111111111111111111111111111111111"),
+            b256!("0x2222222222222222222222222222222222222222222222222222222222222222"),
+        );
+        let decoded = Eip2612PermitData::abi_decode(&bytes).unwrap();
+        assert_eq!(decoded.value, U256::from(1_000u64));
+        assert_eq!(decoded.deadline, U256::from(1_770_000_000u64));
+        assert_eq!(decoded.v, 27);
+    }
+}

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/errors.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/errors.rs
@@ -37,6 +37,8 @@ pub const ERR_ERC3009_AUTHORIZATION_REQUIRED: &str =
 pub const ERR_REFUND_TRANSACTION_FAILED: &str =
     "invalid_batch_settlement_evm_refund_transaction_failed";
 pub const ERR_INVALID_PAYLOAD_TYPE: &str = "invalid_batch_settlement_evm_payload_type";
+pub const ERR_DEPOSIT_PAYLOAD: &str = "invalid_batch_settlement_evm_deposit_payload";
+pub const ERR_CLAIM_PAYLOAD: &str = "invalid_batch_settlement_evm_claim_payload";
 pub const ERR_WITHDRAW_DELAY_OUT_OF_RANGE: &str =
     "invalid_batch_settlement_evm_withdraw_delay_out_of_range";
 pub const ERR_CHANNEL_ID_MISMATCH: &str = "invalid_batch_settlement_evm_channel_id_mismatch";
@@ -120,6 +122,8 @@ mod tests {
             ERR_ERC3009_AUTHORIZATION_REQUIRED,
             ERR_REFUND_TRANSACTION_FAILED,
             ERR_INVALID_PAYLOAD_TYPE,
+            ERR_DEPOSIT_PAYLOAD,
+            ERR_CLAIM_PAYLOAD,
             ERR_WITHDRAW_DELAY_OUT_OF_RANGE,
             ERR_CHANNEL_ID_MISMATCH,
             ERR_RECEIVER_MISMATCH,

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/errors.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/errors.rs
@@ -1,0 +1,160 @@
+//! Error code constants for the `batch-settlement` EVM scheme.
+//!
+//! Mirrors `typescript/packages/mechanisms/evm/src/batch-settlement/errors.ts` and
+//! the Go reference in `go/mechanisms/evm/batch-settlement/errors.go`. The exact
+//! string values are part of the wire format: facilitators, servers, and clients
+//! across implementations match on these to surface compatible diagnostics.
+
+#![allow(missing_docs)]
+
+// --- Facilitator: verification & settlement errors --------------------------
+
+pub const ERR_CHANNEL_NOT_FOUND: &str = "invalid_batch_settlement_evm_channel_not_found";
+pub const ERR_TOKEN_MISMATCH: &str = "invalid_batch_settlement_evm_token_mismatch";
+pub const ERR_INVALID_VOUCHER_SIGNATURE: &str = "invalid_batch_settlement_evm_voucher_signature";
+pub const ERR_CUMULATIVE_EXCEEDS_BALANCE: &str =
+    "invalid_batch_settlement_evm_cumulative_exceeds_balance";
+pub const ERR_CUMULATIVE_AMOUNT_BELOW_CLAIMED: &str =
+    "invalid_batch_settlement_evm_cumulative_below_claimed";
+pub const ERR_INSUFFICIENT_BALANCE: &str = "invalid_batch_settlement_evm_insufficient_balance";
+pub const ERR_DEPOSIT_TRANSACTION_FAILED: &str =
+    "invalid_batch_settlement_evm_deposit_transaction_failed";
+pub const ERR_CLAIM_TRANSACTION_FAILED: &str =
+    "invalid_batch_settlement_evm_claim_transaction_failed";
+pub const ERR_SETTLE_TRANSACTION_FAILED: &str =
+    "invalid_batch_settlement_evm_settle_transaction_failed";
+pub const ERR_INVALID_SCHEME: &str = "invalid_batch_settlement_evm_scheme";
+pub const ERR_NETWORK_MISMATCH: &str = "invalid_batch_settlement_evm_network_mismatch";
+pub const ERR_MISSING_EIP712_DOMAIN: &str = "invalid_batch_settlement_evm_missing_eip712_domain";
+pub const ERR_VALID_BEFORE_EXPIRED: &str =
+    "invalid_batch_settlement_evm_payload_authorization_valid_before";
+pub const ERR_VALID_AFTER_IN_FUTURE: &str =
+    "invalid_batch_settlement_evm_payload_authorization_valid_after";
+pub const ERR_INVALID_RECEIVE_AUTHORIZATION_SIGNATURE: &str =
+    "invalid_batch_settlement_evm_receive_authorization_signature";
+pub const ERR_ERC3009_AUTHORIZATION_REQUIRED: &str =
+    "invalid_batch_settlement_evm_erc3009_authorization_required";
+pub const ERR_REFUND_TRANSACTION_FAILED: &str =
+    "invalid_batch_settlement_evm_refund_transaction_failed";
+pub const ERR_INVALID_PAYLOAD_TYPE: &str = "invalid_batch_settlement_evm_payload_type";
+pub const ERR_WITHDRAW_DELAY_OUT_OF_RANGE: &str =
+    "invalid_batch_settlement_evm_withdraw_delay_out_of_range";
+pub const ERR_CHANNEL_ID_MISMATCH: &str = "invalid_batch_settlement_evm_channel_id_mismatch";
+pub const ERR_RECEIVER_MISMATCH: &str = "invalid_batch_settlement_evm_receiver_mismatch";
+pub const ERR_RECEIVER_AUTHORIZER_MISMATCH: &str =
+    "invalid_batch_settlement_evm_receiver_authorizer_mismatch";
+pub const ERR_WITHDRAW_DELAY_MISMATCH: &str =
+    "invalid_batch_settlement_evm_withdraw_delay_mismatch";
+pub const ERR_AUTHORIZER_ADDRESS_MISMATCH: &str =
+    "invalid_batch_settlement_evm_authorizer_address_mismatch";
+pub const ERR_DEPOSIT_SIMULATION_FAILED: &str =
+    "invalid_batch_settlement_evm_deposit_simulation_failed";
+pub const ERR_CLAIM_SIMULATION_FAILED: &str =
+    "invalid_batch_settlement_evm_claim_simulation_failed";
+pub const ERR_SETTLE_SIMULATION_FAILED: &str =
+    "invalid_batch_settlement_evm_settle_simulation_failed";
+pub const ERR_REFUND_PAYLOAD: &str = "invalid_batch_settlement_evm_refund_payload";
+pub const ERR_REFUND_SIMULATION_FAILED: &str =
+    "invalid_batch_settlement_evm_refund_simulation_failed";
+pub const ERR_RPC_READ_FAILED: &str = "invalid_batch_settlement_evm_rpc_read_failed";
+
+pub const ERR_PERMIT2_AUTHORIZATION_REQUIRED: &str =
+    "invalid_batch_settlement_evm_permit2_authorization_required";
+pub const ERR_PERMIT2_INVALID_SPENDER: &str =
+    "invalid_batch_settlement_evm_permit2_invalid_spender";
+pub const ERR_PERMIT2_AMOUNT_MISMATCH: &str =
+    "invalid_batch_settlement_evm_permit2_amount_mismatch";
+pub const ERR_PERMIT2_DEADLINE_EXPIRED: &str =
+    "invalid_batch_settlement_evm_permit2_deadline_expired";
+pub const ERR_PERMIT2_INVALID_SIGNATURE: &str =
+    "invalid_batch_settlement_evm_permit2_invalid_signature";
+pub const ERR_PERMIT2_ALLOWANCE_REQUIRED: &str =
+    "invalid_batch_settlement_evm_permit2_allowance_required";
+
+pub const ERR_EIP2612_AMOUNT_MISMATCH: &str =
+    "invalid_batch_settlement_evm_eip2612_amount_mismatch";
+pub const ERR_EIP2612_OWNER_MISMATCH: &str = "invalid_batch_settlement_evm_eip2612_owner_mismatch";
+pub const ERR_EIP2612_ASSET_MISMATCH: &str = "invalid_batch_settlement_evm_eip2612_asset_mismatch";
+pub const ERR_EIP2612_SPENDER_MISMATCH: &str =
+    "invalid_batch_settlement_evm_eip2612_spender_mismatch";
+pub const ERR_EIP2612_DEADLINE_EXPIRED: &str =
+    "invalid_batch_settlement_evm_eip2612_deadline_expired";
+pub const ERR_ERC20_APPROVAL_UNAVAILABLE: &str =
+    "invalid_batch_settlement_evm_erc20_approval_unavailable";
+
+// --- Resource server: 402 corrective / lifecycle reasons --------------------
+
+pub const ERR_CUMULATIVE_AMOUNT_MISMATCH: &str =
+    "invalid_batch_settlement_evm_cumulative_amount_mismatch";
+pub const ERR_CHANNEL_BUSY: &str = "invalid_batch_settlement_evm_channel_busy";
+pub const ERR_CHARGE_EXCEEDS_SIGNED_CUMULATIVE: &str =
+    "invalid_batch_settlement_evm_charge_exceeds_signed_cumulative";
+pub const ERR_MISSING_CHANNEL: &str = "invalid_batch_settlement_evm_missing_channel";
+pub const ERR_REFUND_NO_BALANCE: &str = "invalid_batch_settlement_evm_refund_no_balance";
+pub const ERR_REFUND_AMOUNT_INVALID: &str = "invalid_batch_settlement_evm_refund_amount_invalid";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_codes_use_canonical_prefix() {
+        // Every error code is part of the wire format; the canonical
+        // `invalid_batch_settlement_evm_` prefix is required for interop.
+        for code in [
+            ERR_CHANNEL_NOT_FOUND,
+            ERR_TOKEN_MISMATCH,
+            ERR_INVALID_VOUCHER_SIGNATURE,
+            ERR_CUMULATIVE_EXCEEDS_BALANCE,
+            ERR_CUMULATIVE_AMOUNT_BELOW_CLAIMED,
+            ERR_INSUFFICIENT_BALANCE,
+            ERR_DEPOSIT_TRANSACTION_FAILED,
+            ERR_CLAIM_TRANSACTION_FAILED,
+            ERR_SETTLE_TRANSACTION_FAILED,
+            ERR_INVALID_SCHEME,
+            ERR_NETWORK_MISMATCH,
+            ERR_MISSING_EIP712_DOMAIN,
+            ERR_VALID_BEFORE_EXPIRED,
+            ERR_VALID_AFTER_IN_FUTURE,
+            ERR_INVALID_RECEIVE_AUTHORIZATION_SIGNATURE,
+            ERR_ERC3009_AUTHORIZATION_REQUIRED,
+            ERR_REFUND_TRANSACTION_FAILED,
+            ERR_INVALID_PAYLOAD_TYPE,
+            ERR_WITHDRAW_DELAY_OUT_OF_RANGE,
+            ERR_CHANNEL_ID_MISMATCH,
+            ERR_RECEIVER_MISMATCH,
+            ERR_RECEIVER_AUTHORIZER_MISMATCH,
+            ERR_WITHDRAW_DELAY_MISMATCH,
+            ERR_AUTHORIZER_ADDRESS_MISMATCH,
+            ERR_DEPOSIT_SIMULATION_FAILED,
+            ERR_CLAIM_SIMULATION_FAILED,
+            ERR_SETTLE_SIMULATION_FAILED,
+            ERR_REFUND_PAYLOAD,
+            ERR_REFUND_SIMULATION_FAILED,
+            ERR_RPC_READ_FAILED,
+            ERR_PERMIT2_AUTHORIZATION_REQUIRED,
+            ERR_PERMIT2_INVALID_SPENDER,
+            ERR_PERMIT2_AMOUNT_MISMATCH,
+            ERR_PERMIT2_DEADLINE_EXPIRED,
+            ERR_PERMIT2_INVALID_SIGNATURE,
+            ERR_PERMIT2_ALLOWANCE_REQUIRED,
+            ERR_EIP2612_AMOUNT_MISMATCH,
+            ERR_EIP2612_OWNER_MISMATCH,
+            ERR_EIP2612_ASSET_MISMATCH,
+            ERR_EIP2612_SPENDER_MISMATCH,
+            ERR_EIP2612_DEADLINE_EXPIRED,
+            ERR_ERC20_APPROVAL_UNAVAILABLE,
+            ERR_CUMULATIVE_AMOUNT_MISMATCH,
+            ERR_CHANNEL_BUSY,
+            ERR_CHARGE_EXCEEDS_SIGNED_CUMULATIVE,
+            ERR_MISSING_CHANNEL,
+            ERR_REFUND_NO_BALANCE,
+            ERR_REFUND_AMOUNT_INVALID,
+        ] {
+            assert!(
+                code.starts_with("invalid_batch_settlement_evm_"),
+                "missing canonical prefix on {code}"
+            );
+        }
+    }
+}

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/abi.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/abi.rs
@@ -1,0 +1,214 @@
+//! Strongly typed alloy bindings for the deployed `x402BatchSettlement`
+//! contract and its EIP-712 typed-data structs.
+//!
+//! These bindings are derived from
+//! `typescript/packages/mechanisms/evm/src/batch-settlement/abi.ts` and
+//! cover every entry point the facilitator needs:
+//! - `deposit`, `claim`, `claimWithSignature`, `settle`
+//! - `refund`, `refundWithSignature`
+//! - `initiateWithdraw`, `finalizeWithdraw`
+//! - read-only views: `channels`, `pendingWithdrawals`, `refundNonce`,
+//!   `getVoucherDigest`, `getRefundDigest`, `getClaimBatchDigest`, `getChannelId`,
+//!   `CHANNEL_CONFIG_TYPEHASH`
+//! - the `Settled` event
+//! - the `multicall(bytes[])` aggregator (used for batched claim+refund)
+//!
+//! The EIP-712 structs (`ChannelConfig`, `Voucher`, `Refund`, `ClaimBatch`,
+//! `ReceiveWithAuthorization`, `PermitWitnessTransferFrom`) live alongside the
+//! contract ABI so they can be hashed through `alloy_sol_types::SolStruct`.
+
+#![allow(missing_docs)]
+
+use alloy_sol_types::sol;
+
+sol! {
+    /// Channel identity is derived from this immutable config struct.
+    ///
+    /// `channelId = EIP712Hash(ChannelConfig)` under the
+    /// `x402 Batch Settlement` domain, binding the config to the EVM
+    /// `chainId` and the deployed `x402BatchSettlement` address.
+    #[derive(Debug)]
+    struct ChannelConfig {
+        address payer;
+        address payerAuthorizer;
+        address receiver;
+        address receiverAuthorizer;
+        address token;
+        uint40 withdrawDelay;
+        bytes32 salt;
+    }
+
+    /// Cumulative voucher: signed by the payer (or payer authorizer) to
+    /// authorize the receiver to claim up to `maxClaimableAmount` from a
+    /// specific channel.
+    #[derive(Debug)]
+    struct Voucher {
+        bytes32 channelId;
+        uint128 maxClaimableAmount;
+    }
+
+    /// Cooperative refund authorization: signed by the receiver authorizer
+    /// to release a partial or full refund to the payer.
+    #[derive(Debug)]
+    struct Refund {
+        bytes32 channelId;
+        uint256 nonce;
+        uint128 amount;
+    }
+
+    /// Batched claim entry — flattened form expected by `ClaimBatch`.
+    #[derive(Debug)]
+    struct ClaimEntry {
+        bytes32 channelId;
+        uint128 maxClaimableAmount;
+        uint128 totalClaimed;
+    }
+
+    /// Batched claim authorization: signed by the receiver authorizer to
+    /// authorize a `claimWithSignature` over several channels at once.
+    #[derive(Debug)]
+    struct ClaimBatch {
+        ClaimEntry[] claims;
+    }
+
+    /// ERC-3009 `ReceiveWithAuthorization` typed data used by the
+    /// `ERC3009DepositCollector` to pull funds from the payer into the
+    /// batch-settlement escrow.
+    #[derive(Debug)]
+    struct ReceiveWithAuthorization {
+        address from;
+        address to;
+        uint256 value;
+        uint256 validAfter;
+        uint256 validBefore;
+        bytes32 nonce;
+    }
+
+    /// Permit2 token-permissions segment, used inside the channel-bound
+    /// `PermitWitnessTransferFrom`.
+    #[derive(Debug)]
+    struct TokenPermissions {
+        address token;
+        uint256 amount;
+    }
+
+    /// Channel-bound witness for the Permit2 deposit collector.
+    #[derive(Debug)]
+    struct DepositWitness {
+        bytes32 channelId;
+    }
+
+    /// Permit2 typed data for channel-bound batch deposits.
+    #[derive(Debug)]
+    struct PermitWitnessTransferFrom {
+        TokenPermissions permitted;
+        address spender;
+        uint256 nonce;
+        uint256 deadline;
+        DepositWitness witness;
+    }
+
+    /// Voucher claim row consumed by `claim` / `claimWithSignature`.
+    #[derive(Debug)]
+    struct VoucherClaim {
+        VoucherClaimInner voucher;
+        bytes signature;
+        uint128 totalClaimed;
+    }
+
+    /// Inner voucher view used by `VoucherClaim`. Mirrors the upstream ABI
+    /// `voucher: { channel, maxClaimableAmount }` shape.
+    #[derive(Debug)]
+    struct VoucherClaimInner {
+        ChannelConfig channel;
+        uint128 maxClaimableAmount;
+    }
+
+    /// `x402BatchSettlement` contract bindings.
+    #[allow(clippy::too_many_arguments)]
+    #[derive(Debug)]
+    #[sol(rpc)]
+    contract X402BatchSettlement {
+        function multicall(bytes[] data) external returns (bytes[] results);
+
+        function deposit(
+            ChannelConfig config,
+            uint128 amount,
+            address collector,
+            bytes collectorData
+        ) external;
+
+        function claim(VoucherClaim[] voucherClaims) external;
+
+        function claimWithSignature(
+            VoucherClaim[] voucherClaims,
+            bytes authorizerSignature
+        ) external;
+
+        function settle(address receiver, address token) external;
+
+        function initiateWithdraw(ChannelConfig config, uint128 amount) external;
+
+        function finalizeWithdraw(ChannelConfig config) external;
+
+        function refund(ChannelConfig config, uint128 amount) external;
+
+        function refundWithSignature(
+            ChannelConfig config,
+            uint128 amount,
+            uint256 nonce,
+            bytes receiverAuthorizerSignature
+        ) external;
+
+        function getChannelId(ChannelConfig config) external view returns (bytes32);
+
+        function CHANNEL_CONFIG_TYPEHASH() external view returns (bytes32);
+
+        function channels(bytes32 channelId)
+            external
+            view
+            returns (uint128 balance, uint128 totalClaimed);
+
+        function pendingWithdrawals(bytes32 channelId)
+            external
+            view
+            returns (uint128 amount, uint40 initiatedAt);
+
+        function receivers(address receiver, address token)
+            external
+            view
+            returns (uint128 totalClaimed, uint128 totalSettled);
+
+        function getVoucherDigest(bytes32 channelId, uint128 maxClaimableAmount)
+            external
+            view
+            returns (bytes32);
+
+        function getRefundDigest(bytes32 channelId, uint256 nonce, uint128 amount)
+            external
+            view
+            returns (bytes32);
+
+        function refundNonce(bytes32 channelId) external view returns (uint256);
+
+        function getClaimBatchDigest(VoucherClaim[] voucherClaims)
+            external
+            view
+            returns (bytes32);
+
+        event Settled(
+            address indexed receiver,
+            address indexed token,
+            address indexed sender,
+            uint128 amount
+        );
+    }
+
+    /// Minimal ERC-20 interface for `balanceOf` / `allowance` reads.
+    #[derive(Debug)]
+    #[sol(rpc)]
+    contract IERC20View {
+        function balanceOf(address account) external view returns (uint256);
+        function allowance(address owner, address spender) external view returns (uint256);
+    }
+}

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/authorizer_signer.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/authorizer_signer.rs
@@ -1,0 +1,266 @@
+//! Receiver-authorizer signature helpers.
+//!
+//! Mirrors `typescript/packages/mechanisms/evm/src/batch-settlement/authorizerSigner.ts`.
+//!
+//! A `ReceiverAuthorizerSigner` holds the EOA key designated as
+//! `channelConfig.receiverAuthorizer` and produces EIP-712 signatures for:
+//!
+//! - `claimWithSignature(...)` — the `ClaimBatch` typed-data digest binds
+//!   every voucher in the batch to the authorizer's address.
+//! - `refundWithSignature(...)` — the `Refund` typed-data digest binds the
+//!   channel id, refund nonce, and amount.
+//!
+//! The facilitator wires this in when the server delegates receiver-authorizer
+//! signing to it (`channelConfig.receiverAuthorizer == authorizer.address`).
+//! Servers that hold their own receiver-authorizer key supply the signatures
+//! inline in the settle payload, in which case the facilitator's
+//! [`ReceiverAuthorizerSigner`] is unused for that request.
+
+use alloy_primitives::{Address, B256, Bytes, U128, U256};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolStruct;
+
+use super::abi::{
+    ClaimBatch, ClaimEntry, Refund as RefundStruct, Voucher as VoucherStruct,
+    VoucherClaim as VoucherClaimAbi, VoucherClaimInner as VoucherClaimInnerAbi,
+};
+use super::utils::{batch_settlement_domain, compute_channel_id, to_abi_channel_config};
+use crate::v2_eip155_batch_settlement::types::VoucherClaim;
+
+/// Wraps a private key dedicated to receiver-authorizer signing.
+///
+/// Decoupled from the chain provider's signer pool: the receiver authorizer
+/// key is part of the channel identity (it shapes `channelId`), and rotating
+/// it without breaking outstanding vouchers requires opening new channels.
+#[derive(Debug, Clone)]
+pub struct ReceiverAuthorizerSigner {
+    signer: PrivateKeySigner,
+}
+
+impl ReceiverAuthorizerSigner {
+    /// Constructs a new signer from a raw secp256k1 private key.
+    pub fn new(signer: PrivateKeySigner) -> Self {
+        Self { signer }
+    }
+
+    /// The receiver-authorizer EOA address — published in
+    /// `SupportedResponse.kinds[].extra.receiverAuthorizer`.
+    pub fn address(&self) -> Address {
+        self.signer.address()
+    }
+
+    /// Produces an EIP-712 signature over the `ClaimBatch` digest for the
+    /// given claim rows.
+    pub fn sign_claim_batch(
+        &self,
+        claims: &[VoucherClaim],
+        chain_id: u64,
+    ) -> Result<Bytes, alloy_signer::Error> {
+        let entries: Vec<ClaimEntry> = claims
+            .iter()
+            .map(|c| ClaimEntry {
+                channelId: compute_channel_id(&c.voucher.channel, chain_id),
+                maxClaimableAmount: c.voucher.max_claimable_amount.0.to::<u128>(),
+                totalClaimed: c.total_claimed.0.to::<u128>(),
+            })
+            .collect();
+        let batch = ClaimBatch { claims: entries };
+        let digest = batch.eip712_signing_hash(&batch_settlement_domain(chain_id));
+        let signature = self.signer.sign_hash_sync(&digest)?;
+        Ok(signature.as_bytes().to_vec().into())
+    }
+
+    /// Produces an EIP-712 signature over the `Refund` digest.
+    pub fn sign_refund(
+        &self,
+        channel_id: B256,
+        amount: U128,
+        nonce: U256,
+        chain_id: u64,
+    ) -> Result<Bytes, alloy_signer::Error> {
+        let refund = RefundStruct {
+            channelId: channel_id,
+            nonce,
+            amount: amount.to::<u128>(),
+        };
+        let digest = refund.eip712_signing_hash(&batch_settlement_domain(chain_id));
+        let signature = self.signer.sign_hash_sync(&digest)?;
+        Ok(signature.as_bytes().to_vec().into())
+    }
+}
+
+/// Builds the `VoucherClaim` ABI tuple expected by `claim` / `claimWithSignature`.
+pub fn to_abi_voucher_claims(claims: &[VoucherClaim]) -> Vec<VoucherClaimAbi> {
+    claims
+        .iter()
+        .map(|c| VoucherClaimAbi {
+            voucher: VoucherClaimInnerAbi {
+                channel: to_abi_channel_config(&c.voucher.channel),
+                maxClaimableAmount: c.voucher.max_claimable_amount.0.to::<u128>(),
+            },
+            signature: c.signature.clone(),
+            totalClaimed: c.total_claimed.0.to::<u128>(),
+        })
+        .collect()
+}
+
+/// EIP-712 digest helper used to cross-check that a server-supplied claim batch
+/// signature came from the expected receiver authorizer.
+pub fn compute_claim_batch_digest(claims: &[VoucherClaim], chain_id: u64) -> B256 {
+    let entries: Vec<ClaimEntry> = claims
+        .iter()
+        .map(|c| ClaimEntry {
+            channelId: compute_channel_id(&c.voucher.channel, chain_id),
+            maxClaimableAmount: c.voucher.max_claimable_amount.0.to::<u128>(),
+            totalClaimed: c.total_claimed.0.to::<u128>(),
+        })
+        .collect();
+    ClaimBatch { claims: entries }.eip712_signing_hash(&batch_settlement_domain(chain_id))
+}
+
+/// EIP-712 digest helper for cross-checking a refund authorizer signature.
+pub fn compute_refund_digest(channel_id: B256, amount: U128, nonce: U256, chain_id: u64) -> B256 {
+    RefundStruct {
+        channelId: channel_id,
+        nonce,
+        amount: amount.to::<u128>(),
+    }
+    .eip712_signing_hash(&batch_settlement_domain(chain_id))
+}
+
+/// EIP-712 digest helper for cross-checking a voucher signature.
+pub fn compute_voucher_struct_digest(
+    channel_id: B256,
+    max_claimable_amount: U128,
+    chain_id: u64,
+) -> B256 {
+    VoucherStruct {
+        channelId: channel_id,
+        maxClaimableAmount: max_claimable_amount.to::<u128>(),
+    }
+    .eip712_signing_hash(&batch_settlement_domain(chain_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v2_eip155_batch_settlement::types::{
+        ChannelConfig as WireChannelConfig, VoucherClaim, VoucherClaimVoucher,
+    };
+    use alloy_primitives::B256;
+
+    fn sample_config() -> WireChannelConfig {
+        WireChannelConfig {
+            payer: "0x0000000000000000000000000000000000000001"
+                .parse()
+                .unwrap(),
+            payer_authorizer: "0x0000000000000000000000000000000000000002"
+                .parse()
+                .unwrap(),
+            receiver: "0x0000000000000000000000000000000000000003"
+                .parse()
+                .unwrap(),
+            receiver_authorizer: "0x0000000000000000000000000000000000000004"
+                .parse()
+                .unwrap(),
+            token: "0x0000000000000000000000000000000000000005"
+                .parse()
+                .unwrap(),
+            withdraw_delay: 900,
+            salt: B256::ZERO,
+        }
+    }
+
+    #[test]
+    fn sign_refund_signature_verifies_against_authorizer_address() {
+        let signer = PrivateKeySigner::random();
+        let authorizer_addr = signer.address();
+        let authorizer = ReceiverAuthorizerSigner::new(signer);
+
+        let channel_id = B256::repeat_byte(0xaa);
+        let amount = U128::from(500u128);
+        let nonce = U256::from(1u64);
+        let chain_id = 84532u64;
+
+        let sig_bytes = authorizer
+            .sign_refund(channel_id, amount, nonce, chain_id)
+            .unwrap();
+        let digest = compute_refund_digest(channel_id, amount, nonce, chain_id);
+
+        let sig = alloy_primitives::Signature::from_raw(&sig_bytes)
+            .unwrap()
+            .normalized_s();
+        let recovered = sig.recover_address_from_prehash(&digest).unwrap();
+        assert_eq!(recovered, authorizer_addr);
+    }
+
+    #[test]
+    fn sign_claim_batch_signature_verifies_against_authorizer_address() {
+        let signer = PrivateKeySigner::random();
+        let authorizer_addr = signer.address();
+        let authorizer = ReceiverAuthorizerSigner::new(signer);
+        let chain_id = 84532u64;
+
+        let claims = vec![VoucherClaim {
+            voucher: VoucherClaimVoucher {
+                channel: sample_config(),
+                max_claimable_amount: U128::from(5_000u128).into(),
+            },
+            // The voucher signature itself doesn't matter for the claim-batch
+            // authorizer digest — only the entries do.
+            signature: alloy_primitives::Bytes::from_static(&[]),
+            total_claimed: U128::from(5_000u128).into(),
+        }];
+
+        let sig_bytes = authorizer.sign_claim_batch(&claims, chain_id).unwrap();
+        let digest = compute_claim_batch_digest(&claims, chain_id);
+
+        let sig = alloy_primitives::Signature::from_raw(&sig_bytes)
+            .unwrap()
+            .normalized_s();
+        let recovered = sig.recover_address_from_prehash(&digest).unwrap();
+        assert_eq!(recovered, authorizer_addr);
+    }
+
+    /// Two different chains must yield different `Refund` digests so a refund
+    /// signed for chain A cannot be replayed against chain B.
+    #[test]
+    fn refund_digest_is_chain_bound() {
+        let channel_id = B256::repeat_byte(0xbb);
+        let amount = U128::from(500u128);
+        let nonce = U256::from(2u64);
+        let base = compute_refund_digest(channel_id, amount, nonce, 8453);
+        let optimism = compute_refund_digest(channel_id, amount, nonce, 10);
+        assert_ne!(base, optimism);
+    }
+
+    #[test]
+    fn voucher_struct_digest_is_chain_bound() {
+        let channel_id = B256::repeat_byte(0xcc);
+        let amount = U128::from(1_000u128);
+        let base = compute_voucher_struct_digest(channel_id, amount, 8453);
+        let optimism = compute_voucher_struct_digest(channel_id, amount, 10);
+        assert_ne!(base, optimism);
+    }
+
+    #[test]
+    fn to_abi_voucher_claims_preserves_amounts_and_signatures() {
+        let claims = vec![VoucherClaim {
+            voucher: VoucherClaimVoucher {
+                channel: sample_config(),
+                max_claimable_amount: U128::from(7_000u128).into(),
+            },
+            signature: alloy_primitives::Bytes::from_static(&[0xab, 0xcd]),
+            total_claimed: U128::from(7_000u128).into(),
+        }];
+        let abi = to_abi_voucher_claims(&claims);
+        assert_eq!(abi.len(), 1);
+        assert_eq!(abi[0].voucher.maxClaimableAmount, 7_000u128);
+        assert_eq!(abi[0].totalClaimed, 7_000u128);
+        assert_eq!(
+            abi[0].signature,
+            alloy_primitives::Bytes::from_static(&[0xab, 0xcd])
+        );
+    }
+}

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/mod.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/mod.rs
@@ -1,0 +1,230 @@
+//! Facilitator-side implementation of the V2 EIP-155 `batch-settlement` scheme.
+//!
+//! The facilitator implements three operations:
+//!
+//! - [`X402SchemeFacilitator::verify`]   — validate a payment payload (deposit,
+//!   voucher, or refund) without committing onchain. Returns the onchain
+//!   channel snapshot so the server can keep its mirrored state fresh.
+//! - [`X402SchemeFacilitator::settle`]   — execute one of four settle actions
+//!   (deposit, claim, settle, refund) onchain. Surfaces the transaction hash
+//!   and a post-tx channel snapshot.
+//! - [`X402SchemeFacilitator::supported`] — advertise the scheme and the
+//!   facilitator's `receiverAuthorizer` address (when configured) so servers
+//!   can delegate authorizer signing to the facilitator.
+//!
+//! Configuration:
+//!
+//! ```json
+//! {
+//!   "id": "v2-eip155-batch-settlement",
+//!   "chains": "eip155:*",
+//!   "config": {
+//!     "receiverAuthorizerPrivateKey": "0x...",
+//!     "eip2612GasSponsoring": false
+//!   }
+//! }
+//! ```
+//!
+//! - `receiverAuthorizerPrivateKey` is optional. When set, the facilitator
+//!   exposes the derived EOA as `extra.receiverAuthorizer` in
+//!   `SupportedResponse.kinds[].extra` and signs missing claim / refund
+//!   authorizer signatures with it. When unset, servers must hold their
+//!   own receiver-authorizer key and supply signatures inline.
+//! - `eip2612GasSponsoring` is reserved for the future EIP-2612 inline-permit
+//!   deposit branch. The baseline port relays Permit2 deposits with the
+//!   standard branch only.
+
+pub mod abi;
+pub mod authorizer_signer;
+pub mod response;
+pub mod settle;
+pub mod utils;
+pub mod verify;
+pub mod voucher;
+
+pub use authorizer_signer::ReceiverAuthorizerSigner;
+pub use response::{
+    BatchSettlementSettleExtra, BatchSettlementSettleResponse, BatchSettlementVerifyExtra,
+    BatchSettlementVerifyResponse,
+};
+pub use utils::{OnchainChannelState, compute_channel_id, compute_voucher_digest};
+
+use alloy_provider::Provider;
+use alloy_signer_local::PrivateKeySigner;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use x402_types::chain::ChainProviderOps;
+use x402_types::proto;
+use x402_types::proto::v2;
+use x402_types::scheme::{
+    X402SchemeFacilitator, X402SchemeFacilitatorBuilder, X402SchemeFacilitatorError,
+};
+
+use crate::V2Eip155BatchSettlement;
+use crate::chain::{Eip155ChainReference, Eip155MetaTransactionProvider, MetaTransactionSendError};
+use crate::v2_eip155_batch_settlement::constants::BATCH_SETTLEMENT_SCHEME;
+use crate::v2_eip155_batch_settlement::types as wire;
+
+/// JSON-configured options for the batch-settlement facilitator.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct V2Eip155BatchSettlementConfig {
+    /// Hex-encoded private key (0x-prefixed) for the facilitator's
+    /// receiver authorizer EOA. When unset, the facilitator does not
+    /// advertise a `receiverAuthorizer` in `supported()` and cannot
+    /// sign missing claim / refund authorizer signatures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receiver_authorizer_private_key: Option<String>,
+    /// Reserved: enable the EIP-2612 inline-permit branch for Permit2 deposits.
+    /// The baseline port does not implement this branch; setting `true`
+    /// today has no effect.
+    #[serde(default)]
+    pub eip2612_gas_sponsoring: bool,
+}
+
+impl<P> X402SchemeFacilitatorBuilder<P> for V2Eip155BatchSettlement
+where
+    P: Eip155MetaTransactionProvider + ChainProviderOps + Send + Sync + 'static,
+    P::Error: Into<MetaTransactionSendError>,
+{
+    fn build(
+        &self,
+        provider: P,
+        config: Option<serde_json::Value>,
+    ) -> Result<Box<dyn X402SchemeFacilitator>, Box<dyn std::error::Error>> {
+        let config: V2Eip155BatchSettlementConfig = match config {
+            Some(value) => serde_json::from_value(value)?,
+            None => V2Eip155BatchSettlementConfig::default(),
+        };
+
+        let receiver_authorizer = match &config.receiver_authorizer_private_key {
+            Some(hex) => {
+                let signer: PrivateKeySigner =
+                    hex.parse().map_err(|e| -> Box<dyn std::error::Error> {
+                        format!("invalid receiverAuthorizerPrivateKey: {e}").into()
+                    })?;
+                Some(ReceiverAuthorizerSigner::new(signer))
+            }
+            None => None,
+        };
+
+        Ok(Box::new(V2Eip155BatchSettlementFacilitator {
+            provider,
+            receiver_authorizer,
+        }))
+    }
+}
+
+/// Facilitator implementation for V2 EIP-155 `batch-settlement`.
+///
+/// Decoupled from any single provider implementation — accepts anything that
+/// implements [`Eip155MetaTransactionProvider`] + [`ChainProviderOps`], so it
+/// can be exercised with a mock provider in tests.
+pub struct V2Eip155BatchSettlementFacilitator<P> {
+    provider: P,
+    receiver_authorizer: Option<ReceiverAuthorizerSigner>,
+}
+
+impl<P> V2Eip155BatchSettlementFacilitator<P> {
+    /// Constructs a facilitator directly (bypassing JSON config).
+    pub fn new(provider: P, receiver_authorizer: Option<ReceiverAuthorizerSigner>) -> Self {
+        Self {
+            provider,
+            receiver_authorizer,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<P> X402SchemeFacilitator for V2Eip155BatchSettlementFacilitator<P>
+where
+    P: Eip155MetaTransactionProvider + ChainProviderOps + Send + Sync,
+    P::Inner: Provider,
+    P::Error: Into<MetaTransactionSendError>,
+{
+    async fn verify(
+        &self,
+        request: &proto::VerifyRequest,
+    ) -> Result<proto::VerifyResponse, X402SchemeFacilitatorError> {
+        let typed: wire::VerifyRequest = wire::VerifyRequest::try_from(request)?;
+        let chain_id = chain_id_u64(self.provider.chain());
+        let response = verify::verify(
+            self.provider.inner(),
+            chain_id,
+            &typed.payment_payload,
+            &typed.payment_requirements,
+        )
+        .await;
+        Ok(response.into())
+    }
+
+    async fn settle(
+        &self,
+        request: &proto::SettleRequest,
+    ) -> Result<proto::SettleResponse, X402SchemeFacilitatorError> {
+        let typed: wire::SettleRequest = wire::SettleRequest::try_from(request)?;
+        let chain_id = chain_id_u64(self.provider.chain());
+        let response = settle::settle(
+            &self.provider,
+            chain_id,
+            self.receiver_authorizer.as_ref(),
+            &typed.payment_payload,
+            &typed.payment_requirements,
+        )
+        .await;
+        Ok(response.into())
+    }
+
+    async fn supported(&self) -> Result<proto::SupportedResponse, X402SchemeFacilitatorError> {
+        let chain_id = self.provider.chain_id();
+        let extra = self.receiver_authorizer.as_ref().map(|signer| {
+            serde_json::json!({
+                "receiverAuthorizer": signer.address().to_checksum(None),
+            })
+        });
+        let kinds = vec![proto::SupportedPaymentKind {
+            x402_version: v2::X402Version2.into(),
+            scheme: BATCH_SETTLEMENT_SCHEME.to_string(),
+            network: chain_id.clone().into(),
+            extra,
+        }];
+        let mut signers = HashMap::with_capacity(1);
+        signers.insert(chain_id, self.provider.signer_addresses());
+        Ok(proto::SupportedResponse {
+            kinds,
+            extensions: Vec::new(),
+            signers,
+        })
+    }
+}
+
+fn chain_id_u64(chain: &Eip155ChainReference) -> u64 {
+    chain.inner()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_signer_local::PrivateKeySigner;
+
+    #[test]
+    fn config_parses_with_authorizer_key() {
+        let signer = PrivateKeySigner::random();
+        let hex = format!("{:#x}", signer.to_bytes());
+        let json = serde_json::json!({
+            "receiverAuthorizerPrivateKey": hex,
+            "eip2612GasSponsoring": false,
+        });
+        let parsed: V2Eip155BatchSettlementConfig = serde_json::from_value(json).unwrap();
+        assert!(parsed.receiver_authorizer_private_key.is_some());
+        assert!(!parsed.eip2612_gas_sponsoring);
+    }
+
+    #[test]
+    fn config_defaults_round_trip() {
+        let json = serde_json::json!({});
+        let parsed: V2Eip155BatchSettlementConfig = serde_json::from_value(json).unwrap();
+        assert!(parsed.receiver_authorizer_private_key.is_none());
+        assert!(!parsed.eip2612_gas_sponsoring);
+    }
+}

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/response.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/response.rs
@@ -1,0 +1,272 @@
+//! Verify / settle response wire types for batch-settlement.
+//!
+//! The scheme extends the standard V2 `VerifyResponse` / `SettleResponse`
+//! with an `extra` block that carries the onchain channel snapshot
+//! (`channelState`). Servers consume that snapshot to keep their mirrored
+//! state fresh and emit the corrective 402 when the client falls behind.
+
+use serde::{Deserialize, Serialize};
+use x402_types::proto;
+
+use super::utils::OnchainChannelState;
+use crate::v2_eip155_batch_settlement::types::{ChannelStateExtra, U128String, U256String};
+
+/// Verify-response extra block: the onchain channel snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchSettlementVerifyExtra {
+    pub channel_id: alloy_primitives::B256,
+    pub balance: U128String,
+    pub total_claimed: U128String,
+    pub withdraw_requested_at: u64,
+    pub refund_nonce: U256String,
+}
+
+impl BatchSettlementVerifyExtra {
+    /// Builds the verify extra from an onchain snapshot + channel id.
+    pub fn from_state(channel_id: alloy_primitives::B256, state: &OnchainChannelState) -> Self {
+        Self {
+            channel_id,
+            balance: state.balance.into(),
+            total_claimed: state.total_claimed.into(),
+            withdraw_requested_at: state.withdraw_requested_at,
+            refund_nonce: state.refund_nonce.into(),
+        }
+    }
+}
+
+/// Settle-response extra block: nested `channelState` snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchSettlementSettleExtra {
+    pub channel_state: ChannelStateExtra,
+}
+
+/// Wire format for the batch-settlement-flavoured `VerifyResponse`.
+///
+/// Distinct from `proto::v1::VerifyResponse` (which has no `extra` slot).
+/// Converts into [`proto::VerifyResponse`] via the standard JSON pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchSettlementVerifyResponse {
+    pub is_valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payer: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invalid_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invalid_message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<BatchSettlementVerifyExtra>,
+}
+
+impl BatchSettlementVerifyResponse {
+    /// Constructs a success response with the channel snapshot.
+    pub fn valid(payer: String, extra: BatchSettlementVerifyExtra) -> Self {
+        Self {
+            is_valid: true,
+            payer: Some(payer),
+            invalid_reason: None,
+            invalid_message: None,
+            extra: Some(extra),
+        }
+    }
+
+    /// Constructs a verification-failure response.
+    pub fn invalid(payer: Option<String>, reason: &'static str) -> Self {
+        Self {
+            is_valid: false,
+            payer,
+            invalid_reason: Some(reason.to_string()),
+            invalid_message: None,
+            extra: None,
+        }
+    }
+
+    /// Convenience constructor that also surfaces a free-form `invalidMessage`
+    /// alongside the canonical reason code.
+    pub fn invalid_with_message(
+        payer: Option<String>,
+        reason: &'static str,
+        message: String,
+    ) -> Self {
+        Self {
+            is_valid: false,
+            payer,
+            invalid_reason: Some(reason.to_string()),
+            invalid_message: Some(message),
+            extra: None,
+        }
+    }
+}
+
+impl From<BatchSettlementVerifyResponse> for proto::VerifyResponse {
+    fn from(value: BatchSettlementVerifyResponse) -> Self {
+        proto::VerifyResponse(
+            serde_json::to_value(value)
+                .expect("BatchSettlementVerifyResponse serialization failed"),
+        )
+    }
+}
+
+/// Wire format for the batch-settlement-flavoured `SettleResponse`.
+///
+/// Mirrors the upstream `SettleResponse` shape used by the TypeScript
+/// reference, which carries `transaction`, `payer`, `amount`, and a
+/// scheme-specific `extra` block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchSettlementSettleResponse {
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    pub transaction: String,
+    pub network: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payer: Option<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub amount: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<BatchSettlementSettleExtra>,
+}
+
+impl BatchSettlementSettleResponse {
+    /// Constructs an error settle response with a canonical reason code.
+    pub fn failure(network: String, reason: &'static str) -> Self {
+        Self {
+            success: false,
+            error_reason: Some(reason.to_string()),
+            error_message: None,
+            transaction: String::new(),
+            network,
+            payer: None,
+            amount: String::new(),
+            extra: None,
+        }
+    }
+
+    /// Same as [`failure`] but with a free-form diagnostic message.
+    pub fn failure_with_message(network: String, reason: &'static str, message: String) -> Self {
+        Self {
+            success: false,
+            error_reason: Some(reason.to_string()),
+            error_message: Some(message),
+            transaction: String::new(),
+            network,
+            payer: None,
+            amount: String::new(),
+            extra: None,
+        }
+    }
+}
+
+impl From<BatchSettlementSettleResponse> for proto::SettleResponse {
+    fn from(value: BatchSettlementSettleResponse) -> Self {
+        proto::SettleResponse(
+            serde_json::to_value(value)
+                .expect("BatchSettlementSettleResponse serialization failed"),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{B256, U128, U256};
+    use serde_json::json;
+
+    #[test]
+    fn verify_valid_serializes_camel_case_with_channel_state() {
+        let extra = BatchSettlementVerifyExtra {
+            channel_id: B256::repeat_byte(0xaa),
+            balance: U128::from(1_000u128).into(),
+            total_claimed: U128::from(500u128).into(),
+            withdraw_requested_at: 0,
+            refund_nonce: U256::from(1u64).into(),
+        };
+        let resp = BatchSettlementVerifyResponse::valid("0xPayer".into(), extra);
+        let json = serde_json::to_value(resp).unwrap();
+        assert_eq!(json["isValid"], true);
+        assert_eq!(json["payer"], "0xPayer");
+        assert_eq!(json["extra"]["balance"], "1000");
+        assert_eq!(json["extra"]["totalClaimed"], "500");
+        assert_eq!(json["extra"]["refundNonce"], "1");
+    }
+
+    #[test]
+    fn verify_invalid_omits_extra() {
+        let resp = BatchSettlementVerifyResponse::invalid(
+            Some("0xPayer".into()),
+            "invalid_batch_settlement_evm_voucher_signature",
+        );
+        let json = serde_json::to_value(resp).unwrap();
+        assert_eq!(json["isValid"], false);
+        assert_eq!(
+            json["invalidReason"],
+            "invalid_batch_settlement_evm_voucher_signature"
+        );
+        assert!(json.get("extra").is_none() || json["extra"].is_null());
+    }
+
+    #[test]
+    fn settle_response_serializes_extra() {
+        let resp = BatchSettlementSettleResponse {
+            success: true,
+            error_reason: None,
+            error_message: None,
+            transaction: String::new(),
+            network: "eip155:84532".into(),
+            payer: Some("0xPayer".into()),
+            amount: String::new(),
+            extra: Some(BatchSettlementSettleExtra {
+                channel_state: ChannelStateExtra {
+                    channel_id: B256::repeat_byte(0xab),
+                    balance: U128::from(100_000u128).into(),
+                    total_claimed: U128::from(3_900u128).into(),
+                    withdraw_requested_at: 0,
+                    refund_nonce: U256::from(1u64).into(),
+                    charged_cumulative_amount: None,
+                },
+            }),
+        };
+        let json = serde_json::to_value(resp).unwrap();
+        assert_eq!(json["success"], true);
+        assert_eq!(json["extra"]["channelState"]["balance"], "100000");
+    }
+
+    #[test]
+    fn settle_failure_has_empty_transaction_and_amount() {
+        let resp = BatchSettlementSettleResponse::failure(
+            "eip155:84532".into(),
+            "invalid_batch_settlement_evm_settle_simulation_failed",
+        );
+        let json = serde_json::to_value(resp).unwrap();
+        assert_eq!(json["success"], false);
+        assert_eq!(json["transaction"], "");
+        assert_eq!(json["network"], "eip155:84532");
+        assert_eq!(
+            json["errorReason"],
+            "invalid_batch_settlement_evm_settle_simulation_failed"
+        );
+        assert!(json.get("amount").is_none() || json["amount"] == json!(""));
+    }
+
+    #[test]
+    fn verify_response_round_trips_via_value() {
+        let extra = BatchSettlementVerifyExtra {
+            channel_id: B256::repeat_byte(0xaa),
+            balance: U128::from(1_000u128).into(),
+            total_claimed: U128::from(500u128).into(),
+            withdraw_requested_at: 42,
+            refund_nonce: U256::from(0u64).into(),
+        };
+        let resp = BatchSettlementVerifyResponse::valid("0xPayer".into(), extra);
+        let json = serde_json::to_value(&resp).unwrap();
+        let back: BatchSettlementVerifyResponse = serde_json::from_value(json).unwrap();
+        assert!(back.is_valid);
+        assert_eq!(back.payer.as_deref(), Some("0xPayer"));
+        assert_eq!(back.extra.unwrap().withdraw_requested_at, 42);
+    }
+}

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/settle.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/settle.rs
@@ -1,0 +1,773 @@
+//! Settle dispatcher for the batch-settlement scheme.
+//!
+//! Drives the four settlement actions the facilitator can perform on behalf
+//! of clients and servers:
+//!
+//! - `deposit`  — submit `deposit(config, amount, collector, collectorData)`
+//! - `claim`    — submit `claimWithSignature(claims, authorizerSignature)`
+//! - `settle`   — submit `settle(receiver, token)`
+//! - `refund`   — submit `refundWithSignature(config, amount, nonce, sig)`
+//!
+//! On success the response carries the transaction hash and an `extra` block
+//! with the post-transaction channel snapshot when applicable.
+
+use alloy_primitives::{Address, B256, Bytes, U128, U256};
+use alloy_provider::Provider;
+use alloy_sol_types::SolCall;
+
+use super::abi::X402BatchSettlement::{
+    claimCall, claimWithSignatureCall, depositCall, multicallCall, refundWithSignatureCall,
+    settleCall,
+};
+use super::authorizer_signer::{
+    ReceiverAuthorizerSigner, compute_claim_batch_digest, compute_refund_digest,
+    to_abi_voucher_claims,
+};
+use super::response::BatchSettlementSettleExtra;
+use super::response::BatchSettlementSettleResponse;
+use super::utils::{compute_channel_id, read_channel_state, to_abi_channel_config};
+use super::verify::verify;
+use crate::chain::{Eip155MetaTransactionProvider, MetaTransaction, MetaTransactionSendError};
+use crate::v2_eip155_batch_settlement::constants::{
+    BATCH_SETTLEMENT_ADDRESS, ERC3009_DEPOSIT_COLLECTOR_ADDRESS, PERMIT2_DEPOSIT_COLLECTOR_ADDRESS,
+};
+use crate::v2_eip155_batch_settlement::encoding::{
+    build_erc3009_collector_data, build_permit2_collector_data,
+};
+use crate::v2_eip155_batch_settlement::errors as err;
+use crate::v2_eip155_batch_settlement::types::{
+    BatchSettlementPayload, BatchSettlementRefundPayload, ChannelStateExtra, ClaimPayload,
+    DepositAuthorization, DepositPayload, EnrichedRefundPayload, PaymentPayload,
+    PaymentRequirements, SettlePayload,
+};
+
+/// Top-level settle dispatcher.
+pub async fn settle<P>(
+    provider: &P,
+    chain_id: u64,
+    receiver_authorizer: Option<&ReceiverAuthorizerSigner>,
+    payment_payload: &PaymentPayload,
+    requirements: &PaymentRequirements,
+) -> BatchSettlementSettleResponse
+where
+    P: Eip155MetaTransactionProvider + Send + Sync,
+    P::Inner: Provider,
+    P::Error: Into<MetaTransactionSendError>,
+{
+    let network = requirements.network.to_string();
+
+    if payment_payload.accepted.network != requirements.network {
+        return BatchSettlementSettleResponse::failure(network, err::ERR_NETWORK_MISMATCH);
+    }
+
+    match &payment_payload.payload {
+        BatchSettlementPayload::Deposit(deposit) => {
+            settle_deposit(provider, chain_id, payment_payload, deposit, requirements).await
+        }
+        BatchSettlementPayload::Claim(claim) => {
+            settle_claim(provider, chain_id, receiver_authorizer, claim, requirements).await
+        }
+        BatchSettlementPayload::Settle(payload) => {
+            settle_transfer(provider, payload, requirements).await
+        }
+        BatchSettlementPayload::Refund(BatchSettlementRefundPayload::Enriched(enriched)) => {
+            settle_refund(
+                provider,
+                chain_id,
+                receiver_authorizer,
+                enriched,
+                requirements,
+            )
+            .await
+        }
+        BatchSettlementPayload::Refund(BatchSettlementRefundPayload::Client(_))
+        | BatchSettlementPayload::Voucher(_) => {
+            // Bare client refund / voucher payloads must be enriched and
+            // promoted to a settle action by the server first.
+            BatchSettlementSettleResponse::failure(network, err::ERR_INVALID_PAYLOAD_TYPE)
+        }
+    }
+}
+
+async fn settle_deposit<P>(
+    provider: &P,
+    chain_id: u64,
+    payment_payload: &PaymentPayload,
+    payload: &DepositPayload,
+    requirements: &PaymentRequirements,
+) -> BatchSettlementSettleResponse
+where
+    P: Eip155MetaTransactionProvider + Send + Sync,
+    P::Inner: Provider,
+    P::Error: Into<MetaTransactionSendError>,
+{
+    let network = requirements.network.to_string();
+    // 1. Verify the payload first — the same checks that ran on `/verify`
+    //    must hold here, and we get the pre-tx channel snapshot for the
+    //    response back.
+    let verified = verify(provider.inner(), chain_id, payment_payload, requirements).await;
+    if !verified.is_valid {
+        return failure_from_verify(&network, verified);
+    }
+    let pre_extra = match verified.extra {
+        Some(e) => e,
+        None => {
+            return BatchSettlementSettleResponse::failure(
+                network,
+                err::ERR_DEPOSIT_TRANSACTION_FAILED,
+            );
+        }
+    };
+    let payer = verified
+        .payer
+        .clone()
+        .unwrap_or_else(|| Address::from(payload.channel_config.payer).to_checksum(None));
+
+    // 2. Build the deposit collector data + collector address.
+    let (collector, collector_data) = match &payload.deposit.authorization {
+        DepositAuthorization::Erc3009(auth) => (
+            ERC3009_DEPOSIT_COLLECTOR_ADDRESS,
+            build_erc3009_collector_data(
+                auth.valid_after.0,
+                auth.valid_before.0,
+                auth.salt,
+                &auth.signature,
+            ),
+        ),
+        DepositAuthorization::Permit2(auth) => (
+            PERMIT2_DEPOSIT_COLLECTOR_ADDRESS,
+            // The EIP-2612 gas-sponsoring branch attaches an inline permit
+            // segment here. For the baseline production port we forward
+            // `0x` and require the payer to already have a Permit2 allowance.
+            build_permit2_collector_data(
+                auth.nonce.0,
+                auth.deadline.0,
+                &auth.signature,
+                &Bytes::new(),
+            ),
+        ),
+    };
+
+    let Some(deposit_amount_u128) = u256_to_u128(payload.deposit.amount.0) else {
+        return BatchSettlementSettleResponse::failure(
+            network,
+            err::ERR_DEPOSIT_TRANSACTION_FAILED,
+        );
+    };
+
+    // 3. Submit the deposit transaction.
+    let calldata: Bytes = depositCall {
+        config: to_abi_channel_config(&payload.channel_config),
+        amount: deposit_amount_u128.to::<u128>(),
+        collector,
+        collectorData: collector_data,
+    }
+    .abi_encode()
+    .into();
+
+    let receipt = match provider
+        .send_transaction(MetaTransaction::new(BATCH_SETTLEMENT_ADDRESS, calldata))
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            let msg: MetaTransactionSendError = e.into();
+            return BatchSettlementSettleResponse::failure_with_message(
+                network,
+                err::ERR_DEPOSIT_TRANSACTION_FAILED,
+                msg.to_string(),
+            );
+        }
+    };
+    if !receipt.status() {
+        return BatchSettlementSettleResponse::failure_with_message(
+            network,
+            err::ERR_DEPOSIT_TRANSACTION_FAILED,
+            format!("transaction reverted (status {})", receipt.status()),
+        );
+    }
+    let tx_hash = receipt.transaction_hash;
+
+    // 4. Build the response. We optimistically project the new channel state
+    //    by adding the deposit to the pre-state balance; if the RPC has
+    //    already caught up to the new balance, we use the fresh read instead.
+    let optimistic_balance = pre_extra.balance.0.saturating_add(deposit_amount_u128);
+    let mut extra_state = ChannelStateExtra {
+        channel_id: pre_extra.channel_id,
+        balance: optimistic_balance.into(),
+        total_claimed: pre_extra.total_claimed,
+        withdraw_requested_at: pre_extra.withdraw_requested_at,
+        refund_nonce: pre_extra.refund_nonce,
+        charged_cumulative_amount: None,
+    };
+
+    if let Ok(post) = read_channel_state(provider.inner(), pre_extra.channel_id).await
+        && post.balance >= optimistic_balance
+    {
+        extra_state.balance = post.balance.into();
+        extra_state.total_claimed = post.total_claimed.into();
+        extra_state.withdraw_requested_at = post.withdraw_requested_at;
+        extra_state.refund_nonce = post.refund_nonce.into();
+    }
+
+    BatchSettlementSettleResponse {
+        success: true,
+        error_reason: None,
+        error_message: None,
+        transaction: format!("{tx_hash:#x}"),
+        network,
+        payer: Some(payer),
+        amount: payload.deposit.amount.0.to_string(),
+        extra: Some(BatchSettlementSettleExtra {
+            channel_state: extra_state,
+        }),
+    }
+}
+
+async fn settle_claim<P>(
+    provider: &P,
+    chain_id: u64,
+    authorizer: Option<&ReceiverAuthorizerSigner>,
+    payload: &ClaimPayload,
+    requirements: &PaymentRequirements,
+) -> BatchSettlementSettleResponse
+where
+    P: Eip155MetaTransactionProvider + Send + Sync,
+    P::Inner: Provider,
+    P::Error: Into<MetaTransactionSendError>,
+{
+    let network = requirements.network.to_string();
+
+    let signature = match resolve_claim_authorizer_signature(payload, authorizer, chain_id) {
+        Ok(sig) => sig,
+        Err(reason) => return BatchSettlementSettleResponse::failure(network, reason),
+    };
+
+    let calls = to_abi_voucher_claims(&payload.claims);
+    let calldata = match signature.as_ref() {
+        Some(sig_bytes) => claimWithSignatureCall {
+            voucherClaims: calls,
+            authorizerSignature: sig_bytes.clone(),
+        }
+        .abi_encode(),
+        None => claimCall {
+            voucherClaims: calls,
+        }
+        .abi_encode(),
+    };
+
+    submit_to_batch_settlement(
+        provider,
+        network,
+        calldata,
+        err::ERR_CLAIM_TRANSACTION_FAILED,
+    )
+    .await
+}
+
+async fn settle_transfer<P>(
+    provider: &P,
+    payload: &SettlePayload,
+    requirements: &PaymentRequirements,
+) -> BatchSettlementSettleResponse
+where
+    P: Eip155MetaTransactionProvider + Send + Sync,
+    P::Inner: Provider,
+    P::Error: Into<MetaTransactionSendError>,
+{
+    let network = requirements.network.to_string();
+    let calldata = settleCall {
+        receiver: payload.receiver.into(),
+        token: payload.token.into(),
+    }
+    .abi_encode();
+
+    let receipt = match provider
+        .send_transaction(MetaTransaction::new(
+            BATCH_SETTLEMENT_ADDRESS,
+            calldata.into(),
+        ))
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            let msg: MetaTransactionSendError = e.into();
+            return BatchSettlementSettleResponse::failure_with_message(
+                network,
+                err::ERR_SETTLE_TRANSACTION_FAILED,
+                msg.to_string(),
+            );
+        }
+    };
+    if !receipt.status() {
+        return BatchSettlementSettleResponse::failure_with_message(
+            network,
+            err::ERR_SETTLE_TRANSACTION_FAILED,
+            format!("transaction reverted (status {})", receipt.status()),
+        );
+    }
+    let tx_hash = receipt.transaction_hash;
+
+    // Pick the `Settled` event amount, if present. Without it, fall back to
+    // an empty amount (the upstream impl returns "" for no-op settles).
+    let amount = extract_settled_amount(&receipt, payload.receiver.into(), payload.token.into())
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+
+    BatchSettlementSettleResponse {
+        success: true,
+        error_reason: None,
+        error_message: None,
+        transaction: format!("{tx_hash:#x}"),
+        network,
+        payer: None,
+        amount,
+        extra: None,
+    }
+}
+
+async fn settle_refund<P>(
+    provider: &P,
+    chain_id: u64,
+    authorizer: Option<&ReceiverAuthorizerSigner>,
+    payload: &EnrichedRefundPayload,
+    requirements: &PaymentRequirements,
+) -> BatchSettlementSettleResponse
+where
+    P: Eip155MetaTransactionProvider + Send + Sync,
+    P::Inner: Provider,
+    P::Error: Into<MetaTransactionSendError>,
+{
+    let network = requirements.network.to_string();
+
+    let channel_id = compute_channel_id(&payload.channel_config, chain_id);
+
+    let Some(amount_u128) = u256_to_u128(payload.amount.0) else {
+        return BatchSettlementSettleResponse::failure(network, err::ERR_REFUND_PAYLOAD);
+    };
+
+    let refund_sig = match resolve_refund_authorizer_signature(
+        payload,
+        authorizer,
+        channel_id,
+        amount_u128,
+        chain_id,
+    ) {
+        Ok(sig) => sig,
+        Err(reason) => return BatchSettlementSettleResponse::failure(network, reason),
+    };
+
+    let refund_calldata = refundWithSignatureCall {
+        config: to_abi_channel_config(&payload.channel_config),
+        amount: amount_u128.to::<u128>(),
+        nonce: payload.refund_nonce.0,
+        receiverAuthorizerSignature: refund_sig,
+    }
+    .abi_encode();
+
+    let calldata = if payload.claims.is_empty() {
+        refund_calldata
+    } else {
+        let claim_sig = match resolve_claim_authorizer_signature(
+            &ClaimPayload {
+                claims: payload.claims.clone(),
+                claim_authorizer_signature: payload.claim_authorizer_signature.clone(),
+            },
+            authorizer,
+            chain_id,
+        ) {
+            Ok(sig) => sig,
+            Err(reason) => return BatchSettlementSettleResponse::failure(network, reason),
+        };
+        let claim_calls = to_abi_voucher_claims(&payload.claims);
+        let claim_calldata = match claim_sig {
+            Some(sig_bytes) => claimWithSignatureCall {
+                voucherClaims: claim_calls,
+                authorizerSignature: sig_bytes,
+            }
+            .abi_encode(),
+            None => claimCall {
+                voucherClaims: claim_calls,
+            }
+            .abi_encode(),
+        };
+
+        multicallCall {
+            data: vec![claim_calldata.into(), refund_calldata.into()],
+        }
+        .abi_encode()
+    };
+
+    let receipt = match provider
+        .send_transaction(MetaTransaction::new(
+            BATCH_SETTLEMENT_ADDRESS,
+            calldata.into(),
+        ))
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            let msg: MetaTransactionSendError = e.into();
+            return BatchSettlementSettleResponse::failure_with_message(
+                network,
+                err::ERR_REFUND_TRANSACTION_FAILED,
+                msg.to_string(),
+            );
+        }
+    };
+    if !receipt.status() {
+        return BatchSettlementSettleResponse::failure_with_message(
+            network,
+            err::ERR_REFUND_TRANSACTION_FAILED,
+            format!("transaction reverted (status {})", receipt.status()),
+        );
+    }
+    let tx_hash = receipt.transaction_hash;
+
+    // Read the post-refund snapshot to surface accurate `balance` / `nonce`.
+    let extra = match read_channel_state(provider.inner(), channel_id).await {
+        Ok(state) => ChannelStateExtra {
+            channel_id,
+            balance: state.balance.into(),
+            total_claimed: state.total_claimed.into(),
+            withdraw_requested_at: state.withdraw_requested_at,
+            refund_nonce: state.refund_nonce.into(),
+            charged_cumulative_amount: None,
+        },
+        Err(_) => ChannelStateExtra {
+            channel_id,
+            balance: U128::ZERO.into(),
+            total_claimed: U128::ZERO.into(),
+            withdraw_requested_at: 0,
+            refund_nonce: (payload.refund_nonce.0 + U256::from(1u64)).into(),
+            charged_cumulative_amount: None,
+        },
+    };
+
+    BatchSettlementSettleResponse {
+        success: true,
+        error_reason: None,
+        error_message: None,
+        transaction: format!("{tx_hash:#x}"),
+        network,
+        payer: Some(Address::from(payload.channel_config.payer).to_checksum(None)),
+        amount: payload.amount.0.to_string(),
+        extra: Some(BatchSettlementSettleExtra {
+            channel_state: extra,
+        }),
+    }
+}
+
+/// Routes the calldata at the `x402BatchSettlement` contract, surfacing
+/// receipt status as a canonical error reason on failure.
+async fn submit_to_batch_settlement<P>(
+    provider: &P,
+    network: String,
+    calldata: Vec<u8>,
+    failure_reason: &'static str,
+) -> BatchSettlementSettleResponse
+where
+    P: Eip155MetaTransactionProvider + Send + Sync,
+    P::Inner: Provider,
+    P::Error: Into<MetaTransactionSendError>,
+{
+    let receipt = match provider
+        .send_transaction(MetaTransaction::new(
+            BATCH_SETTLEMENT_ADDRESS,
+            calldata.into(),
+        ))
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            let msg: MetaTransactionSendError = e.into();
+            return BatchSettlementSettleResponse::failure_with_message(
+                network,
+                failure_reason,
+                msg.to_string(),
+            );
+        }
+    };
+    if !receipt.status() {
+        return BatchSettlementSettleResponse::failure_with_message(
+            network,
+            failure_reason,
+            format!("transaction reverted (status {})", receipt.status()),
+        );
+    }
+    let tx_hash = receipt.transaction_hash;
+    BatchSettlementSettleResponse {
+        success: true,
+        error_reason: None,
+        error_message: None,
+        transaction: format!("{tx_hash:#x}"),
+        network,
+        payer: None,
+        amount: String::new(),
+        extra: None,
+    }
+}
+
+fn failure_from_verify(
+    network: &str,
+    verified: super::response::BatchSettlementVerifyResponse,
+) -> BatchSettlementSettleResponse {
+    let reason = verified
+        .invalid_reason
+        .as_deref()
+        .unwrap_or(err::ERR_DEPOSIT_TRANSACTION_FAILED);
+    BatchSettlementSettleResponse {
+        success: false,
+        error_reason: Some(reason.to_string()),
+        error_message: verified.invalid_message.clone(),
+        transaction: String::new(),
+        network: network.to_string(),
+        payer: verified.payer.clone(),
+        amount: String::new(),
+        extra: None,
+    }
+}
+
+fn resolve_claim_authorizer_signature(
+    payload: &ClaimPayload,
+    authorizer: Option<&ReceiverAuthorizerSigner>,
+    chain_id: u64,
+) -> Result<Option<Bytes>, &'static str> {
+    if let Some(existing) = &payload.claim_authorizer_signature {
+        return Ok(Some(existing.clone()));
+    }
+    // No client-supplied signature; sign with the facilitator's authorizer key
+    // if every claim row delegates to that address.
+    let authorizer = authorizer.ok_or(err::ERR_AUTHORIZER_ADDRESS_MISMATCH)?;
+    let want: Address = authorizer.address();
+    for claim in &payload.claims {
+        if Address::from(claim.voucher.channel.receiver_authorizer) != want {
+            return Err(err::ERR_AUTHORIZER_ADDRESS_MISMATCH);
+        }
+    }
+    let sig = authorizer
+        .sign_claim_batch(&payload.claims, chain_id)
+        .map_err(|_| err::ERR_AUTHORIZER_ADDRESS_MISMATCH)?;
+    debug_assert_eq!(
+        recover_signer(&sig, compute_claim_batch_digest(&payload.claims, chain_id)),
+        Some(want)
+    );
+    Ok(Some(sig))
+}
+
+fn resolve_refund_authorizer_signature(
+    payload: &EnrichedRefundPayload,
+    authorizer: Option<&ReceiverAuthorizerSigner>,
+    channel_id: B256,
+    amount: U128,
+    chain_id: u64,
+) -> Result<Bytes, &'static str> {
+    if let Some(existing) = &payload.refund_authorizer_signature {
+        return Ok(existing.clone());
+    }
+    let authorizer = authorizer.ok_or(err::ERR_AUTHORIZER_ADDRESS_MISMATCH)?;
+    let want: Address = authorizer.address();
+    if Address::from(payload.channel_config.receiver_authorizer) != want {
+        return Err(err::ERR_AUTHORIZER_ADDRESS_MISMATCH);
+    }
+    let sig = authorizer
+        .sign_refund(channel_id, amount, payload.refund_nonce.0, chain_id)
+        .map_err(|_| err::ERR_AUTHORIZER_ADDRESS_MISMATCH)?;
+    debug_assert_eq!(
+        recover_signer(
+            &sig,
+            compute_refund_digest(channel_id, amount, payload.refund_nonce.0, chain_id)
+        ),
+        Some(want)
+    );
+    Ok(sig)
+}
+
+/// Recovers the EOA signer from a raw 65-byte signature, returning `None`
+/// if the bytes don't decode or the recovery fails.
+fn recover_signer(signature: &[u8], digest: B256) -> Option<Address> {
+    use alloy_primitives::Signature;
+    let sig = match signature.len() {
+        65 => Signature::from_raw(signature).ok()?.normalized_s(),
+        64 => Signature::from_erc2098(signature).normalized_s(),
+        _ => return None,
+    };
+    sig.recover_address_from_prehash(&digest).ok()
+}
+
+/// Best-effort extraction of the `amount` field of the `Settled(receiver, token, sender, amount)`
+/// event. Returns `None` if the event is not present in the receipt.
+fn extract_settled_amount(
+    receipt: &alloy_rpc_types_eth::TransactionReceipt,
+    receiver: Address,
+    token: Address,
+) -> Option<U128> {
+    use super::abi::X402BatchSettlement::Settled;
+    use alloy_sol_types::SolEvent;
+    for log in receipt.logs() {
+        if log.address() != BATCH_SETTLEMENT_ADDRESS {
+            continue;
+        }
+        let topics = log.topics();
+        // `Settled(receiver, token, sender, amount)` is an indexed-3 event.
+        if topics.len() != 4 || topics[0] != Settled::SIGNATURE_HASH {
+            continue;
+        }
+        let log_receiver = Address::from_slice(&topics[1].as_slice()[12..]);
+        let log_token = Address::from_slice(&topics[2].as_slice()[12..]);
+        if log_receiver == receiver
+            && log_token == token
+            && let Ok(decoded) = Settled::decode_log_data(log.data())
+        {
+            return Some(U128::from(decoded.amount));
+        }
+    }
+    None
+}
+
+fn u256_to_u128(value: U256) -> Option<U128> {
+    let bytes: [u8; 32] = value.to_be_bytes();
+    if bytes[..16].iter().any(|b| *b != 0) {
+        return None;
+    }
+    let mut narrow = [0u8; 16];
+    narrow.copy_from_slice(&bytes[16..]);
+    Some(U128::from_be_bytes(narrow))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v2_eip155_batch_settlement::types::{
+        ChannelConfig as WireChannelConfig, VoucherClaim, VoucherClaimVoucher,
+    };
+    use alloy_primitives::B256;
+    use alloy_signer_local::PrivateKeySigner;
+
+    fn make_config(authorizer: &str) -> WireChannelConfig {
+        WireChannelConfig {
+            payer: "0x0000000000000000000000000000000000000001"
+                .parse()
+                .unwrap(),
+            payer_authorizer: "0x0000000000000000000000000000000000000002"
+                .parse()
+                .unwrap(),
+            receiver: "0x0000000000000000000000000000000000000003"
+                .parse()
+                .unwrap(),
+            receiver_authorizer: authorizer.parse().unwrap(),
+            token: "0x0000000000000000000000000000000000000005"
+                .parse()
+                .unwrap(),
+            withdraw_delay: 900,
+            salt: B256::ZERO,
+        }
+    }
+
+    #[test]
+    fn resolve_claim_signature_uses_provided_signature_when_present() {
+        let claims = vec![VoucherClaim {
+            voucher: VoucherClaimVoucher {
+                channel: make_config("0x0000000000000000000000000000000000000004"),
+                max_claimable_amount: U128::from(1_000u128).into(),
+            },
+            signature: Bytes::from_static(&[0x00]),
+            total_claimed: U128::from(1_000u128).into(),
+        }];
+        let payload = ClaimPayload {
+            claims,
+            claim_authorizer_signature: Some(Bytes::from_static(&[0xab, 0xcd])),
+        };
+        let sig = resolve_claim_authorizer_signature(&payload, None, 84532).unwrap();
+        assert_eq!(sig.as_ref().map(|b| b.as_ref()), Some(&[0xab_u8, 0xcd][..]));
+    }
+
+    #[test]
+    fn resolve_claim_signature_requires_authorizer_when_signature_missing() {
+        let claims = vec![VoucherClaim {
+            voucher: VoucherClaimVoucher {
+                channel: make_config("0x0000000000000000000000000000000000000004"),
+                max_claimable_amount: U128::from(1_000u128).into(),
+            },
+            signature: Bytes::from_static(&[0x00]),
+            total_claimed: U128::from(1_000u128).into(),
+        }];
+        let payload = ClaimPayload {
+            claims,
+            claim_authorizer_signature: None,
+        };
+        let err = resolve_claim_authorizer_signature(&payload, None, 84532).unwrap_err();
+        assert_eq!(err, err::ERR_AUTHORIZER_ADDRESS_MISMATCH);
+    }
+
+    #[test]
+    fn resolve_claim_signature_rejects_mismatched_authorizer() {
+        let local = PrivateKeySigner::random();
+        let signer = ReceiverAuthorizerSigner::new(local);
+        let claims = vec![VoucherClaim {
+            voucher: VoucherClaimVoucher {
+                channel: make_config("0x0000000000000000000000000000000000000099"), // not the signer
+                max_claimable_amount: U128::from(1_000u128).into(),
+            },
+            signature: Bytes::from_static(&[0x00]),
+            total_claimed: U128::from(1_000u128).into(),
+        }];
+        let payload = ClaimPayload {
+            claims,
+            claim_authorizer_signature: None,
+        };
+        let err = resolve_claim_authorizer_signature(&payload, Some(&signer), 84532).unwrap_err();
+        assert_eq!(err, err::ERR_AUTHORIZER_ADDRESS_MISMATCH);
+    }
+
+    #[test]
+    fn resolve_claim_signature_signs_when_authorizer_matches() {
+        let local = PrivateKeySigner::random();
+        let signer = ReceiverAuthorizerSigner::new(local);
+        let authorizer_hex = format!("{:#x}", signer.address());
+        let claims = vec![VoucherClaim {
+            voucher: VoucherClaimVoucher {
+                channel: make_config(&authorizer_hex),
+                max_claimable_amount: U128::from(1_000u128).into(),
+            },
+            signature: Bytes::from_static(&[0x00]),
+            total_claimed: U128::from(1_000u128).into(),
+        }];
+        let payload = ClaimPayload {
+            claims: claims.clone(),
+            claim_authorizer_signature: None,
+        };
+        let sig = resolve_claim_authorizer_signature(&payload, Some(&signer), 84532)
+            .unwrap()
+            .unwrap();
+        // The debug_assertion inside the helper already cross-checks the
+        // recovered signer; verify the output length here as well.
+        assert_eq!(sig.len(), 65);
+    }
+
+    #[test]
+    fn resolve_refund_signature_passes_through_existing_signature() {
+        let payload = EnrichedRefundPayload {
+            channel_config: make_config("0x0000000000000000000000000000000000000004"),
+            voucher: crate::v2_eip155_batch_settlement::types::VoucherFields {
+                channel_id: B256::ZERO,
+                max_claimable_amount: U128::ZERO.into(),
+                signature: Bytes::new(),
+            },
+            amount: U256::from(100u64).into(),
+            refund_nonce: U256::ZERO.into(),
+            claims: Vec::new(),
+            refund_authorizer_signature: Some(Bytes::from_static(&[0xde, 0xad])),
+            claim_authorizer_signature: None,
+        };
+        let sig = resolve_refund_authorizer_signature(
+            &payload,
+            None,
+            B256::ZERO,
+            U128::from(100u128),
+            84532,
+        )
+        .unwrap();
+        assert_eq!(sig.as_ref(), &[0xde, 0xad]);
+    }
+}

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/settle.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/settle.rs
@@ -13,7 +13,9 @@
 
 use alloy_primitives::{Address, B256, Bytes, U128, U256};
 use alloy_provider::Provider;
+use alloy_rpc_types_eth::TransactionRequest;
 use alloy_sol_types::SolCall;
+use tokio::time::{Duration, Instant, sleep};
 
 use super::abi::X402BatchSettlement::{
     claimCall, claimWithSignatureCall, depositCall, multicallCall, refundWithSignatureCall,
@@ -23,9 +25,12 @@ use super::authorizer_signer::{
     ReceiverAuthorizerSigner, compute_claim_batch_digest, compute_refund_digest,
     to_abi_voucher_claims,
 };
-use super::response::BatchSettlementSettleExtra;
-use super::response::BatchSettlementSettleResponse;
-use super::utils::{compute_channel_id, read_channel_state, to_abi_channel_config};
+use super::response::{
+    BatchSettlementSettleExtra, BatchSettlementSettleResponse, BatchSettlementVerifyExtra,
+};
+use super::utils::{
+    OnchainChannelState, compute_channel_id, read_channel_state, to_abi_channel_config,
+};
 use super::verify::verify;
 use crate::chain::{Eip155MetaTransactionProvider, MetaTransaction, MetaTransactionSendError};
 use crate::v2_eip155_batch_settlement::constants::{
@@ -40,6 +45,11 @@ use crate::v2_eip155_batch_settlement::types::{
     DepositAuthorization, DepositPayload, EnrichedRefundPayload, PaymentPayload,
     PaymentRequirements, SettlePayload,
 };
+
+const REFUND_STATE_POLL_DEADLINE: Duration = Duration::from_secs(2);
+const REFUND_STATE_POLL_INTERVAL: Duration = Duration::from_millis(150);
+const DEPOSIT_STATE_POLL_DEADLINE: Duration = Duration::from_secs(2);
+const DEPOSIT_STATE_POLL_INTERVAL: Duration = Duration::from_millis(150);
 
 /// Top-level settle dispatcher.
 pub async fn settle<P>(
@@ -109,7 +119,7 @@ where
     if !verified.is_valid {
         return failure_from_verify(&network, verified);
     }
-    let pre_extra = match verified.extra {
+    let verified_extra = match verified.extra {
         Some(e) => e,
         None => {
             return BatchSettlementSettleResponse::failure(
@@ -136,9 +146,9 @@ where
         ),
         DepositAuthorization::Permit2(auth) => (
             PERMIT2_DEPOSIT_COLLECTOR_ADDRESS,
-            // The EIP-2612 gas-sponsoring branch attaches an inline permit
-            // segment here. For the baseline production port we forward
-            // `0x` and require the payer to already have a Permit2 allowance.
+            // Standard Permit2 prior-allowance path: no inline EIP-2612
+            // permit segment is forwarded, so the payer must already have
+            // approved canonical Permit2 for this token.
             build_permit2_collector_data(
                 auth.nonce.0,
                 auth.deadline.0,
@@ -188,27 +198,11 @@ where
     }
     let tx_hash = receipt.transaction_hash;
 
-    // 4. Build the response. We optimistically project the new channel state
-    //    by adding the deposit to the pre-state balance; if the RPC has
+    // 4. Build the response. Deposit /verify returns the projected
+    //    post-deposit channel state, matching the Go reference. If the RPC has
     //    already caught up to the new balance, we use the fresh read instead.
-    let optimistic_balance = pre_extra.balance.0.saturating_add(deposit_amount_u128);
-    let mut extra_state = ChannelStateExtra {
-        channel_id: pre_extra.channel_id,
-        balance: optimistic_balance.into(),
-        total_claimed: pre_extra.total_claimed,
-        withdraw_requested_at: pre_extra.withdraw_requested_at,
-        refund_nonce: pre_extra.refund_nonce,
-        charged_cumulative_amount: None,
-    };
-
-    if let Ok(post) = read_channel_state(provider.inner(), pre_extra.channel_id).await
-        && post.balance >= optimistic_balance
-    {
-        extra_state.balance = post.balance.into();
-        extra_state.total_claimed = post.total_claimed.into();
-        extra_state.withdraw_requested_at = post.withdraw_requested_at;
-        extra_state.refund_nonce = post.refund_nonce.into();
-    }
+    let extra_state =
+        build_deposit_response_state(provider.inner(), &verified_extra, deposit_amount_u128).await;
 
     BatchSettlementSettleResponse {
         success: true,
@@ -238,6 +232,10 @@ where
 {
     let network = requirements.network.to_string();
 
+    if payload.claims.is_empty() {
+        return BatchSettlementSettleResponse::failure(network, err::ERR_CLAIM_PAYLOAD);
+    }
+
     let signature = match resolve_claim_authorizer_signature(payload, authorizer, chain_id) {
         Ok(sig) => sig,
         Err(reason) => return BatchSettlementSettleResponse::failure(network, reason),
@@ -255,6 +253,15 @@ where
         }
         .abi_encode(),
     };
+    let calldata: Bytes = calldata.into();
+
+    if let Err(message) = simulate_batch_settlement_call(provider.inner(), calldata.clone()).await {
+        return BatchSettlementSettleResponse::failure_with_message(
+            network,
+            err::ERR_CLAIM_SIMULATION_FAILED,
+            message,
+        );
+    }
 
     submit_to_batch_settlement(
         provider,
@@ -276,17 +283,30 @@ where
     P::Error: Into<MetaTransactionSendError>,
 {
     let network = requirements.network.to_string();
-    let calldata = settleCall {
-        receiver: payload.receiver.into(),
-        token: payload.token.into(),
+    let receiver: Address = payload.receiver.into();
+    let token: Address = payload.token.into();
+
+    let required_receiver: Address = requirements.pay_to.into();
+    if receiver != required_receiver {
+        return BatchSettlementSettleResponse::failure(network, err::ERR_RECEIVER_MISMATCH);
     }
-    .abi_encode();
+    let required_token: Address = requirements.asset.into();
+    if token != required_token {
+        return BatchSettlementSettleResponse::failure(network, err::ERR_TOKEN_MISMATCH);
+    }
+
+    let calldata: Bytes = settleCall { receiver, token }.abi_encode().into();
+
+    if let Err(message) = simulate_batch_settlement_call(provider.inner(), calldata.clone()).await {
+        return BatchSettlementSettleResponse::failure_with_message(
+            network,
+            err::ERR_SETTLE_SIMULATION_FAILED,
+            message,
+        );
+    }
 
     let receipt = match provider
-        .send_transaction(MetaTransaction::new(
-            BATCH_SETTLEMENT_ADDRESS,
-            calldata.into(),
-        ))
+        .send_transaction(MetaTransaction::new(BATCH_SETTLEMENT_ADDRESS, calldata))
         .await
     {
         Ok(r) => r,
@@ -308,9 +328,9 @@ where
     }
     let tx_hash = receipt.transaction_hash;
 
-    // Pick the `Settled` event amount, if present. Without it, fall back to
-    // an empty amount (the upstream impl returns "" for no-op settles).
-    let amount = extract_settled_amount(&receipt, payload.receiver.into(), payload.token.into())
+    // Pick the `Settled` event amount, if present. No event keeps the field
+    // empty, matching the Go reference's omitted settle amount.
+    let amount = extract_settled_amount(&receipt, receiver, token)
         .map(|v| v.to_string())
         .unwrap_or_default();
 
@@ -345,6 +365,27 @@ where
     let Some(amount_u128) = u256_to_u128(payload.amount.0) else {
         return BatchSettlementSettleResponse::failure(network, err::ERR_REFUND_PAYLOAD);
     };
+    if amount_u128 == U128::ZERO {
+        return BatchSettlementSettleResponse::failure(network, err::ERR_REFUND_AMOUNT_INVALID);
+    }
+
+    let pre_state = match read_channel_state(provider.inner(), channel_id).await {
+        Ok(state) => state,
+        Err(reason) => return BatchSettlementSettleResponse::failure(network, reason),
+    };
+
+    if payload.refund_nonce.0 != pre_state.refund_nonce {
+        return BatchSettlementSettleResponse::failure(network, err::ERR_REFUND_PAYLOAD);
+    }
+
+    let post_claim_total =
+        match refund_post_claim_total(payload, channel_id, chain_id, pre_state.total_claimed) {
+            Ok(total) => total,
+            Err(reason) => return BatchSettlementSettleResponse::failure(network, reason),
+        };
+    if pre_state.balance <= post_claim_total {
+        return BatchSettlementSettleResponse::failure(network, err::ERR_REFUND_NO_BALANCE);
+    }
 
     let refund_sig = match resolve_refund_authorizer_signature(
         payload,
@@ -357,13 +398,14 @@ where
         Err(reason) => return BatchSettlementSettleResponse::failure(network, reason),
     };
 
-    let refund_calldata = refundWithSignatureCall {
+    let refund_calldata: Bytes = refundWithSignatureCall {
         config: to_abi_channel_config(&payload.channel_config),
         amount: amount_u128.to::<u128>(),
         nonce: payload.refund_nonce.0,
         receiverAuthorizerSignature: refund_sig,
     }
-    .abi_encode();
+    .abi_encode()
+    .into();
 
     let calldata = if payload.claims.is_empty() {
         refund_calldata
@@ -380,29 +422,37 @@ where
             Err(reason) => return BatchSettlementSettleResponse::failure(network, reason),
         };
         let claim_calls = to_abi_voucher_claims(&payload.claims);
-        let claim_calldata = match claim_sig {
+        let claim_calldata: Bytes = match claim_sig {
             Some(sig_bytes) => claimWithSignatureCall {
                 voucherClaims: claim_calls,
                 authorizerSignature: sig_bytes,
             }
-            .abi_encode(),
+            .abi_encode()
+            .into(),
             None => claimCall {
                 voucherClaims: claim_calls,
             }
-            .abi_encode(),
+            .abi_encode()
+            .into(),
         };
 
         multicallCall {
-            data: vec![claim_calldata.into(), refund_calldata.into()],
+            data: vec![claim_calldata, refund_calldata],
         }
         .abi_encode()
+        .into()
     };
 
+    if let Err(message) = simulate_batch_settlement_call(provider.inner(), calldata.clone()).await {
+        return BatchSettlementSettleResponse::failure_with_message(
+            network,
+            err::ERR_REFUND_SIMULATION_FAILED,
+            message,
+        );
+    }
+
     let receipt = match provider
-        .send_transaction(MetaTransaction::new(
-            BATCH_SETTLEMENT_ADDRESS,
-            calldata.into(),
-        ))
+        .send_transaction(MetaTransaction::new(BATCH_SETTLEMENT_ADDRESS, calldata))
         .await
     {
         Ok(r) => r,
@@ -424,25 +474,15 @@ where
     }
     let tx_hash = receipt.transaction_hash;
 
-    // Read the post-refund snapshot to surface accurate `balance` / `nonce`.
-    let extra = match read_channel_state(provider.inner(), channel_id).await {
-        Ok(state) => ChannelStateExtra {
-            channel_id,
-            balance: state.balance.into(),
-            total_claimed: state.total_claimed.into(),
-            withdraw_requested_at: state.withdraw_requested_at,
-            refund_nonce: state.refund_nonce.into(),
-            charged_cumulative_amount: None,
-        },
-        Err(_) => ChannelStateExtra {
-            channel_id,
-            balance: U128::ZERO.into(),
-            total_claimed: U128::ZERO.into(),
-            withdraw_requested_at: 0,
-            refund_nonce: (payload.refund_nonce.0 + U256::from(1u64)).into(),
-            charged_cumulative_amount: None,
-        },
-    };
+    let (actual_refund, extra) = build_refund_response_details(
+        provider.inner(),
+        payload,
+        channel_id,
+        &pre_state,
+        post_claim_total,
+        amount_u128,
+    )
+    .await;
 
     BatchSettlementSettleResponse {
         success: true,
@@ -451,7 +491,7 @@ where
         transaction: format!("{tx_hash:#x}"),
         network,
         payer: Some(Address::from(payload.channel_config.payer).to_checksum(None)),
-        amount: payload.amount.0.to_string(),
+        amount: actual_refund.to_string(),
         extra: Some(BatchSettlementSettleExtra {
             channel_state: extra,
         }),
@@ -463,7 +503,7 @@ where
 async fn submit_to_batch_settlement<P>(
     provider: &P,
     network: String,
-    calldata: Vec<u8>,
+    calldata: Bytes,
     failure_reason: &'static str,
 ) -> BatchSettlementSettleResponse
 where
@@ -472,10 +512,7 @@ where
     P::Error: Into<MetaTransactionSendError>,
 {
     let receipt = match provider
-        .send_transaction(MetaTransaction::new(
-            BATCH_SETTLEMENT_ADDRESS,
-            calldata.into(),
-        ))
+        .send_transaction(MetaTransaction::new(BATCH_SETTLEMENT_ADDRESS, calldata))
         .await
     {
         Ok(r) => r,
@@ -506,6 +543,240 @@ where
         amount: String::new(),
         extra: None,
     }
+}
+
+async fn simulate_batch_settlement_call<P>(provider: &P, calldata: Bytes) -> Result<(), String>
+where
+    P: Provider,
+{
+    let request = TransactionRequest::default()
+        .input(calldata.into())
+        .to(BATCH_SETTLEMENT_ADDRESS);
+    provider
+        .call(request)
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+async fn build_deposit_response_state<P>(
+    provider: &P,
+    verified_extra: &BatchSettlementVerifyExtra,
+    deposit_amount: U128,
+) -> ChannelStateExtra
+where
+    P: Provider,
+{
+    let channel_id = verified_extra.channel_id;
+    let projected_balance = verified_extra.balance.0;
+    let pre_deposit_balance = projected_balance.saturating_sub(deposit_amount);
+    let deadline = Instant::now() + DEPOSIT_STATE_POLL_DEADLINE;
+    let mut last_state = None;
+
+    loop {
+        if let Ok(state) = read_channel_state(provider, channel_id).await {
+            if deposit_post_state_is_usable(
+                &state,
+                verified_extra,
+                projected_balance,
+                pre_deposit_balance,
+            ) {
+                return channel_state_extra_from_state(channel_id, &state);
+            }
+            last_state = Some(state);
+        }
+
+        if Instant::now() >= deadline {
+            break;
+        }
+        sleep(DEPOSIT_STATE_POLL_INTERVAL).await;
+    }
+
+    if let Some(state) = &last_state
+        && deposit_post_state_has_concurrent_change(state, verified_extra, pre_deposit_balance)
+    {
+        return channel_state_extra_from_state(channel_id, state);
+    }
+
+    channel_state_extra_from_verified(verified_extra)
+}
+
+fn deposit_post_state_is_usable(
+    state: &OnchainChannelState,
+    verified_extra: &BatchSettlementVerifyExtra,
+    projected_balance: U128,
+    pre_deposit_balance: U128,
+) -> bool {
+    state.balance >= projected_balance
+        || deposit_post_state_has_concurrent_change(state, verified_extra, pre_deposit_balance)
+}
+
+fn deposit_post_state_has_concurrent_change(
+    state: &OnchainChannelState,
+    verified_extra: &BatchSettlementVerifyExtra,
+    pre_deposit_balance: U128,
+) -> bool {
+    state.balance != pre_deposit_balance
+        || state.total_claimed != verified_extra.total_claimed.0
+        || state.withdraw_requested_at != verified_extra.withdraw_requested_at
+        || state.refund_nonce != verified_extra.refund_nonce.0
+}
+
+fn channel_state_extra_from_state(
+    channel_id: B256,
+    state: &OnchainChannelState,
+) -> ChannelStateExtra {
+    ChannelStateExtra {
+        channel_id,
+        balance: state.balance.into(),
+        total_claimed: state.total_claimed.into(),
+        withdraw_requested_at: state.withdraw_requested_at,
+        refund_nonce: state.refund_nonce.into(),
+        charged_cumulative_amount: None,
+    }
+}
+
+fn channel_state_extra_from_verified(
+    verified_extra: &BatchSettlementVerifyExtra,
+) -> ChannelStateExtra {
+    ChannelStateExtra {
+        channel_id: verified_extra.channel_id,
+        balance: verified_extra.balance.clone(),
+        total_claimed: verified_extra.total_claimed.clone(),
+        withdraw_requested_at: verified_extra.withdraw_requested_at,
+        refund_nonce: verified_extra.refund_nonce.clone(),
+        charged_cumulative_amount: None,
+    }
+}
+
+fn refund_post_claim_total(
+    payload: &EnrichedRefundPayload,
+    channel_id: B256,
+    chain_id: u64,
+    pre_total_claimed: U128,
+) -> Result<U128, &'static str> {
+    let mut post_claim_total = pre_total_claimed;
+    for claim in &payload.claims {
+        let claim_channel_id = compute_channel_id(&claim.voucher.channel, chain_id);
+        if claim_channel_id != channel_id {
+            continue;
+        }
+        if claim.total_claimed.0 > post_claim_total {
+            post_claim_total = claim.total_claimed.0;
+        }
+    }
+    Ok(post_claim_total)
+}
+
+async fn build_refund_response_details<P>(
+    provider: &P,
+    payload: &EnrichedRefundPayload,
+    channel_id: B256,
+    pre_state: &super::utils::OnchainChannelState,
+    post_claim_total: U128,
+    requested_amount: U128,
+) -> (U128, ChannelStateExtra)
+where
+    P: Provider,
+{
+    if let Some(post_state) = read_post_refund_state(
+        provider,
+        channel_id,
+        payload.refund_nonce.0,
+        pre_state.withdraw_requested_at != 0,
+    )
+    .await
+    {
+        let actual_refund = if pre_state.balance > post_state.balance {
+            pre_state.balance - post_state.balance
+        } else {
+            U128::ZERO
+        };
+        return (
+            actual_refund,
+            ChannelStateExtra {
+                channel_id,
+                balance: post_state.balance.into(),
+                total_claimed: post_state.total_claimed.into(),
+                withdraw_requested_at: post_state.withdraw_requested_at,
+                refund_nonce: post_state.refund_nonce.into(),
+                charged_cumulative_amount: None,
+            },
+        );
+    }
+
+    fallback_refund_response_details(
+        channel_id,
+        pre_state.balance,
+        post_claim_total,
+        pre_state.withdraw_requested_amount,
+        pre_state.withdraw_requested_at,
+        payload.refund_nonce.0,
+        requested_amount,
+    )
+}
+
+async fn read_post_refund_state<P>(
+    provider: &P,
+    channel_id: B256,
+    submitted_refund_nonce: U256,
+    poll: bool,
+) -> Option<super::utils::OnchainChannelState>
+where
+    P: Provider,
+{
+    let expected_nonce = submitted_refund_nonce + U256::from(1u64);
+    let deadline = Instant::now() + REFUND_STATE_POLL_DEADLINE;
+    loop {
+        if let Ok(state) = read_channel_state(provider, channel_id).await {
+            if state.refund_nonce == expected_nonce {
+                return Some(state);
+            }
+            if state.refund_nonce > expected_nonce {
+                return None;
+            }
+        }
+
+        if !poll || Instant::now() >= deadline {
+            return None;
+        }
+        sleep(REFUND_STATE_POLL_INTERVAL).await;
+    }
+}
+
+fn fallback_refund_response_details(
+    channel_id: B256,
+    pre_balance: U128,
+    post_claim_total: U128,
+    pre_withdraw_requested_amount: U128,
+    withdraw_requested_at: u64,
+    submitted_refund_nonce: U256,
+    requested_amount: U128,
+) -> (U128, ChannelStateExtra) {
+    let available = pre_balance.saturating_sub(post_claim_total);
+    let actual_refund = if requested_amount > available {
+        available
+    } else {
+        requested_amount
+    };
+    let post_withdraw_requested_at =
+        if withdraw_requested_at == 0 || actual_refund >= pre_withdraw_requested_amount {
+            0
+        } else {
+            withdraw_requested_at
+        };
+
+    (
+        actual_refund,
+        ChannelStateExtra {
+            channel_id,
+            balance: pre_balance.saturating_sub(actual_refund).into(),
+            total_claimed: post_claim_total.into(),
+            withdraw_requested_at: post_withdraw_requested_at,
+            refund_nonce: (submitted_refund_nonce + U256::from(1u64)).into(),
+            charged_cumulative_amount: None,
+        },
+    )
 }
 
 fn failure_from_verify(
@@ -769,5 +1040,180 @@ mod tests {
         )
         .unwrap();
         assert_eq!(sig.as_ref(), &[0xde, 0xad]);
+    }
+
+    #[test]
+    fn refund_post_claim_total_ignores_other_channel_claims() {
+        let chain_id = 84532;
+        let refund_config = make_config("0x0000000000000000000000000000000000000004");
+        let other_config = make_config("0x0000000000000000000000000000000000000099");
+        let refund_channel_id = compute_channel_id(&refund_config, chain_id);
+        let payload = EnrichedRefundPayload {
+            channel_config: refund_config.clone(),
+            voucher: crate::v2_eip155_batch_settlement::types::VoucherFields {
+                channel_id: refund_channel_id,
+                max_claimable_amount: U128::from(1_000u128).into(),
+                signature: Bytes::new(),
+            },
+            amount: U256::from(100u64).into(),
+            refund_nonce: U256::ZERO.into(),
+            claims: vec![
+                VoucherClaim {
+                    voucher: VoucherClaimVoucher {
+                        channel: other_config,
+                        max_claimable_amount: U128::from(9_000u128).into(),
+                    },
+                    signature: Bytes::from_static(&[0x01]),
+                    total_claimed: U128::from(9_000u128).into(),
+                },
+                VoucherClaim {
+                    voucher: VoucherClaimVoucher {
+                        channel: refund_config,
+                        max_claimable_amount: U128::from(500u128).into(),
+                    },
+                    signature: Bytes::from_static(&[0x02]),
+                    total_claimed: U128::from(500u128).into(),
+                },
+            ],
+            refund_authorizer_signature: Some(Bytes::from_static(&[0xde, 0xad])),
+            claim_authorizer_signature: None,
+        };
+
+        let post_claim_total =
+            refund_post_claim_total(&payload, refund_channel_id, chain_id, U128::from(100u128))
+                .unwrap();
+
+        assert_eq!(post_claim_total, U128::from(500u128));
+    }
+
+    #[test]
+    fn fallback_refund_response_caps_amount_to_available_escrow() {
+        let (actual, extra) = fallback_refund_response_details(
+            B256::repeat_byte(0x42),
+            U128::from(1_000u128),
+            U128::from(800u128),
+            U128::ZERO,
+            0,
+            U256::from(2u64),
+            U128::from(500u128),
+        );
+
+        assert_eq!(actual, U128::from(200u128));
+        assert_eq!(extra.balance.0, U128::from(800u128));
+        assert_eq!(extra.total_claimed.0, U128::from(800u128));
+        assert_eq!(extra.refund_nonce.0, U256::from(3u64));
+    }
+
+    #[test]
+    fn fallback_refund_response_uses_requested_amount_when_available() {
+        let (actual, extra) = fallback_refund_response_details(
+            B256::repeat_byte(0x42),
+            U128::from(1_000u128),
+            U128::from(200u128),
+            U128::from(500u128),
+            12,
+            U256::from(0u64),
+            U128::from(300u128),
+        );
+
+        assert_eq!(actual, U128::from(300u128));
+        assert_eq!(extra.balance.0, U128::from(700u128));
+        assert_eq!(extra.total_claimed.0, U128::from(200u128));
+        assert_eq!(extra.withdraw_requested_at, 12);
+        assert_eq!(extra.refund_nonce.0, U256::from(1u64));
+    }
+
+    #[test]
+    fn fallback_refund_response_clears_pending_withdrawal_when_refunded() {
+        let (actual, extra) = fallback_refund_response_details(
+            B256::repeat_byte(0x42),
+            U128::from(1_000u128),
+            U128::from(200u128),
+            U128::from(250u128),
+            12,
+            U256::from(0u64),
+            U128::from(300u128),
+        );
+
+        assert_eq!(actual, U128::from(300u128));
+        assert_eq!(extra.withdraw_requested_at, 0);
+    }
+
+    #[test]
+    fn deposit_post_state_ignores_exact_pre_deposit_snapshot() {
+        let channel_id = B256::repeat_byte(0x42);
+        let verified_extra = BatchSettlementVerifyExtra {
+            channel_id,
+            balance: U128::from(1_500u128).into(),
+            total_claimed: U128::from(200u128).into(),
+            withdraw_requested_at: 0,
+            refund_nonce: U256::from(2u64).into(),
+        };
+        let state = OnchainChannelState {
+            balance: U128::from(1_000u128),
+            total_claimed: U128::from(200u128),
+            withdraw_requested_amount: U128::ZERO,
+            withdraw_requested_at: 0,
+            refund_nonce: U256::from(2u64),
+        };
+
+        assert!(!deposit_post_state_is_usable(
+            &state,
+            &verified_extra,
+            U128::from(1_500u128),
+            U128::from(1_000u128),
+        ));
+    }
+
+    #[test]
+    fn deposit_post_state_accepts_projected_or_newer_balance() {
+        let channel_id = B256::repeat_byte(0x42);
+        let verified_extra = BatchSettlementVerifyExtra {
+            channel_id,
+            balance: U128::from(1_500u128).into(),
+            total_claimed: U128::from(200u128).into(),
+            withdraw_requested_at: 0,
+            refund_nonce: U256::from(2u64).into(),
+        };
+        let state = OnchainChannelState {
+            balance: U128::from(1_500u128),
+            total_claimed: U128::from(200u128),
+            withdraw_requested_amount: U128::ZERO,
+            withdraw_requested_at: 0,
+            refund_nonce: U256::from(2u64),
+        };
+
+        assert!(deposit_post_state_is_usable(
+            &state,
+            &verified_extra,
+            U128::from(1_500u128),
+            U128::from(1_000u128),
+        ));
+    }
+
+    #[test]
+    fn deposit_post_state_accepts_lower_concurrent_change() {
+        let channel_id = B256::repeat_byte(0x42);
+        let verified_extra = BatchSettlementVerifyExtra {
+            channel_id,
+            balance: U128::from(1_500u128).into(),
+            total_claimed: U128::from(200u128).into(),
+            withdraw_requested_at: 0,
+            refund_nonce: U256::from(2u64).into(),
+        };
+        let state = OnchainChannelState {
+            balance: U128::from(900u128),
+            total_claimed: U128::from(200u128),
+            withdraw_requested_amount: U128::ZERO,
+            withdraw_requested_at: 0,
+            refund_nonce: U256::from(3u64),
+        };
+
+        assert!(deposit_post_state_is_usable(
+            &state,
+            &verified_extra,
+            U128::from(1_500u128),
+            U128::from(1_000u128),
+        ));
     }
 }

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/utils.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/utils.rs
@@ -24,6 +24,7 @@ use crate::v2_eip155_batch_settlement::types::{
 pub struct OnchainChannelState {
     pub balance: U128,
     pub total_claimed: U128,
+    pub withdraw_requested_amount: U128,
     pub withdraw_requested_at: u64,
     pub refund_nonce: U256,
 }
@@ -201,6 +202,7 @@ where
     Ok(OnchainChannelState {
         balance: U128::from(channels.balance),
         total_claimed: U128::from(channels.totalClaimed),
+        withdraw_requested_amount: U128::from(pending.amount),
         // `initiatedAt` is `uint40` → `Uint<40, 1>`; truncating to `u64` is
         // lossless because `2^40 - 1 < u64::MAX`.
         withdraw_requested_at: pending.initiatedAt.to::<u64>(),

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/utils.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/utils.rs
@@ -1,0 +1,509 @@
+//! Shared helpers for batch-settlement verify / settle flows.
+//!
+//! Mirrors `typescript/packages/mechanisms/evm/src/batch-settlement/facilitator/utils.ts`.
+
+use alloy_primitives::{Address, B256, U128, U256};
+use alloy_provider::Provider;
+use alloy_sol_types::{Eip712Domain, SolStruct, eip712_domain};
+use x402_types::timestamp::UnixTimestamp;
+
+use super::abi::{ChannelConfig as AbiChannelConfig, Voucher as AbiVoucher, X402BatchSettlement};
+use crate::v2_eip155_batch_settlement::constants::{
+    BATCH_SETTLEMENT_ADDRESS, BATCH_SETTLEMENT_DOMAIN_NAME, BATCH_SETTLEMENT_DOMAIN_VERSION,
+    MAX_WITHDRAW_DELAY, MIN_WITHDRAW_DELAY,
+};
+use crate::v2_eip155_batch_settlement::errors as err;
+use crate::v2_eip155_batch_settlement::types::{
+    BatchSettlementPaymentRequirementsExtra, ChannelConfig as WireChannelConfig,
+    PaymentRequirements,
+};
+
+/// Onchain channel snapshot read via three view calls on the
+/// `x402BatchSettlement` contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OnchainChannelState {
+    pub balance: U128,
+    pub total_claimed: U128,
+    pub withdraw_requested_at: u64,
+    pub refund_nonce: U256,
+}
+
+impl OnchainChannelState {
+    /// True when the channel has never been funded (balance == 0).
+    pub fn is_empty(&self) -> bool {
+        self.balance == U128::ZERO
+    }
+}
+
+/// Builds the chain-bound EIP-712 domain used by every batch-settlement signed
+/// structure (`Voucher`, `Refund`, `ClaimBatch`, `ChannelConfig`).
+pub fn batch_settlement_domain(chain_id: u64) -> Eip712Domain {
+    eip712_domain! {
+        name: BATCH_SETTLEMENT_DOMAIN_NAME,
+        version: BATCH_SETTLEMENT_DOMAIN_VERSION,
+        chain_id: chain_id,
+        verifying_contract: BATCH_SETTLEMENT_ADDRESS,
+    }
+}
+
+/// Converts the wire-format `ChannelConfig` into the ABI tuple expected by the
+/// `x402BatchSettlement` contract calls.
+///
+/// `withdrawDelay` is encoded as `uint40`. Callers validate the value lives
+/// in `[MIN_WITHDRAW_DELAY, MAX_WITHDRAW_DELAY]` before reaching here, so the
+/// `TryFrom<u64>` conversion is infallible in practice; a saturating fallback
+/// preserves the type signature.
+pub fn to_abi_channel_config(config: &WireChannelConfig) -> AbiChannelConfig {
+    let withdraw_delay = alloy_primitives::Uint::<40, 1>::try_from(config.withdraw_delay)
+        .unwrap_or_else(|_| alloy_primitives::Uint::<40, 1>::from(MAX_WITHDRAW_DELAY));
+    AbiChannelConfig {
+        payer: config.payer.into(),
+        payerAuthorizer: config.payer_authorizer.into(),
+        receiver: config.receiver.into(),
+        receiverAuthorizer: config.receiver_authorizer.into(),
+        token: config.token.into(),
+        withdrawDelay: withdraw_delay,
+        salt: config.salt,
+    }
+}
+
+/// Computes the chain-bound channel id from a [`WireChannelConfig`].
+///
+/// `channelId = EIP712Hash(ChannelConfig)` under the `x402 Batch Settlement`
+/// domain. The domain binds the hash to the EVM `chainId` and the deployed
+/// `x402BatchSettlement` address, so the same config produces different
+/// channel ids across chains or deployments.
+pub fn compute_channel_id(config: &WireChannelConfig, chain_id: u64) -> B256 {
+    let domain = batch_settlement_domain(chain_id);
+    let abi = to_abi_channel_config(config);
+    abi.eip712_signing_hash(&domain)
+}
+
+/// Computes the EIP-712 digest a voucher signer commits to.
+///
+/// `maxClaimableAmount` is encoded as `uint128`; `alloy_sol_types::sol!`
+/// emits a native `u128` for that field, so we narrow the wrapped
+/// [`U128`] via `to::<u128>()` (lossless: both have 128-bit width).
+pub fn compute_voucher_digest(channel_id: B256, max_claimable_amount: U128, chain_id: u64) -> B256 {
+    let domain = batch_settlement_domain(chain_id);
+    AbiVoucher {
+        channelId: channel_id,
+        maxClaimableAmount: max_claimable_amount.to::<u128>(),
+    }
+    .eip712_signing_hash(&domain)
+}
+
+/// Validates that a [`WireChannelConfig`] is consistent with the claimed
+/// `channel_id` and the server's [`PaymentRequirements`].
+///
+/// Returns an error code string on mismatch, matching the spec's error
+/// taxonomy. Returns `Ok(())` when the config is well-formed.
+pub fn validate_channel_config(
+    config: &WireChannelConfig,
+    channel_id: B256,
+    requirements: &PaymentRequirements,
+    chain_id: u64,
+) -> Result<(), &'static str> {
+    let computed_id = compute_channel_id(config, chain_id);
+    if computed_id != channel_id {
+        return Err(err::ERR_CHANNEL_ID_MISMATCH);
+    }
+
+    let pay_to: Address = requirements.pay_to.into();
+    if Address::from(config.receiver) != pay_to {
+        return Err(err::ERR_RECEIVER_MISMATCH);
+    }
+
+    let required_authorizer: Address = requirements.extra.receiver_authorizer.into();
+    if required_authorizer == Address::ZERO
+        || Address::from(config.receiver_authorizer) != required_authorizer
+    {
+        return Err(err::ERR_RECEIVER_AUTHORIZER_MISMATCH);
+    }
+
+    let asset: Address = requirements.asset.into();
+    if Address::from(config.token) != asset {
+        return Err(err::ERR_TOKEN_MISMATCH);
+    }
+
+    if config.withdraw_delay != requirements.extra.withdraw_delay {
+        return Err(err::ERR_WITHDRAW_DELAY_MISMATCH);
+    }
+
+    if config.withdraw_delay < MIN_WITHDRAW_DELAY || config.withdraw_delay > MAX_WITHDRAW_DELAY {
+        return Err(err::ERR_WITHDRAW_DELAY_OUT_OF_RANGE);
+    }
+
+    Ok(())
+}
+
+/// Time-window check for an ERC-3009 `ReceiveWithAuthorization`, matching the
+/// reference implementations: a 6-second grace window prevents racy expiries.
+pub fn erc3009_authorization_time_invalid_reason(
+    valid_after: U256,
+    valid_before: U256,
+) -> Option<&'static str> {
+    let now = UnixTimestamp::now().as_secs();
+    let now_u256 = U256::from(now);
+    if valid_before < now_u256 + U256::from(6u64) {
+        return Some(err::ERR_VALID_BEFORE_EXPIRED);
+    }
+    if valid_after > now_u256 {
+        return Some(err::ERR_VALID_AFTER_IN_FUTURE);
+    }
+    None
+}
+
+/// Sanity check that the requirements and the payload's `accepted` block agree
+/// on scheme and network. Returns an error code string on mismatch.
+pub fn assert_scheme_and_network<T>(
+    accepted: &x402_types::proto::v2::PaymentRequirements<
+        crate::v2_eip155_batch_settlement::types::BatchSettlementScheme,
+        crate::v2_eip155_batch_settlement::types::U256String,
+        crate::chain::ChecksummedAddress,
+        BatchSettlementPaymentRequirementsExtra,
+    >,
+    requirements: &PaymentRequirements,
+    _phantom: std::marker::PhantomData<T>,
+) -> Result<(), &'static str> {
+    // The literal scheme types are unit structs constrained to "batch-settlement";
+    // a deserialization-level mismatch would already have been rejected. We
+    // still cross-check the network reference between `accepted` and the
+    // server's requirements to prevent cross-chain payload reuse.
+    if accepted.network != requirements.network {
+        return Err(err::ERR_NETWORK_MISMATCH);
+    }
+    Ok(())
+}
+
+/// Reads the onchain channel snapshot via `channels`, `pendingWithdrawals`,
+/// and `refundNonce`. The three calls are issued concurrently against the
+/// provider; a failure in any of them is mapped to `ERR_RPC_READ_FAILED`.
+pub async fn read_channel_state<P>(
+    provider: &P,
+    channel_id: B256,
+) -> Result<OnchainChannelState, &'static str>
+where
+    P: Provider,
+{
+    let contract = X402BatchSettlement::new(BATCH_SETTLEMENT_ADDRESS, provider);
+    let channels_call = contract.channels(channel_id);
+    let pending_call = contract.pendingWithdrawals(channel_id);
+    let nonce_call = contract.refundNonce(channel_id);
+
+    let (channels_res, pending_res, nonce_res) =
+        tokio::join!(channels_call.call(), pending_call.call(), nonce_call.call());
+
+    let channels = channels_res.map_err(|_| err::ERR_RPC_READ_FAILED)?;
+    let pending = pending_res.map_err(|_| err::ERR_RPC_READ_FAILED)?;
+    let refund_nonce = nonce_res.map_err(|_| err::ERR_RPC_READ_FAILED)?;
+
+    Ok(OnchainChannelState {
+        balance: U128::from(channels.balance),
+        total_claimed: U128::from(channels.totalClaimed),
+        // `initiatedAt` is `uint40` → `Uint<40, 1>`; truncating to `u64` is
+        // lossless because `2^40 - 1 < u64::MAX`.
+        withdraw_requested_at: pending.initiatedAt.to::<u64>(),
+        refund_nonce,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v2_eip155_batch_settlement::types::{
+        BatchSettlementPaymentRequirementsExtra, U256String,
+    };
+    use alloy_primitives::U256;
+    use x402_types::chain::ChainId;
+
+    fn make_requirements(
+        receiver: &str,
+        receiver_authorizer: &str,
+        token: &str,
+        withdraw_delay: u64,
+    ) -> PaymentRequirements {
+        PaymentRequirements {
+            scheme: crate::v2_eip155_batch_settlement::types::BatchSettlementScheme,
+            network: ChainId::new("eip155", "84532"),
+            amount: U256String::from(U256::from(1_000_000u64)),
+            pay_to: receiver.parse().unwrap(),
+            max_timeout_seconds: 300,
+            asset: token.parse().unwrap(),
+            extra: BatchSettlementPaymentRequirementsExtra {
+                receiver_authorizer: receiver_authorizer.parse().unwrap(),
+                withdraw_delay,
+                name: "USDC".into(),
+                version: "2".into(),
+                asset_transfer_method: None,
+                channel_state: None,
+                voucher_state: None,
+            },
+        }
+    }
+
+    fn make_config(
+        payer: &str,
+        payer_authorizer: &str,
+        receiver: &str,
+        receiver_authorizer: &str,
+        token: &str,
+        withdraw_delay: u64,
+    ) -> WireChannelConfig {
+        WireChannelConfig {
+            payer: payer.parse().unwrap(),
+            payer_authorizer: payer_authorizer.parse().unwrap(),
+            receiver: receiver.parse().unwrap(),
+            receiver_authorizer: receiver_authorizer.parse().unwrap(),
+            token: token.parse().unwrap(),
+            withdraw_delay,
+            salt: B256::ZERO,
+        }
+    }
+
+    #[test]
+    fn channel_id_is_chain_bound() {
+        let cfg = make_config(
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000002",
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let id_base = compute_channel_id(&cfg, 8453);
+        let id_optimism = compute_channel_id(&cfg, 10);
+        assert_ne!(
+            id_base, id_optimism,
+            "same config on different chains must hash to different ids"
+        );
+    }
+
+    #[test]
+    fn channel_id_changes_with_salt() {
+        let mut cfg = make_config(
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000002",
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let id1 = compute_channel_id(&cfg, 8453);
+        cfg.salt = B256::repeat_byte(0x11);
+        let id2 = compute_channel_id(&cfg, 8453);
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn channel_id_changes_when_authorizer_changes() {
+        let cfg_a = make_config(
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000002",
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let cfg_b = make_config(
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000099", // different payerAuthorizer
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let id_a = compute_channel_id(&cfg_a, 8453);
+        let id_b = compute_channel_id(&cfg_b, 8453);
+        assert_ne!(id_a, id_b);
+    }
+
+    #[test]
+    fn validate_channel_config_accepts_aligned() {
+        let cfg = make_config(
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000002",
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let req = make_requirements(
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let id = compute_channel_id(&cfg, 84532);
+        assert_eq!(validate_channel_config(&cfg, id, &req, 84532), Ok(()));
+    }
+
+    #[test]
+    fn validate_channel_config_detects_channel_id_mismatch() {
+        let cfg = make_config(
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000002",
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let req = make_requirements(
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let bogus = B256::repeat_byte(0xff);
+        assert_eq!(
+            validate_channel_config(&cfg, bogus, &req, 84532),
+            Err(err::ERR_CHANNEL_ID_MISMATCH)
+        );
+    }
+
+    #[test]
+    fn validate_channel_config_detects_receiver_mismatch() {
+        let cfg = make_config(
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000002",
+            "0x0000000000000000000000000000000000000099",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let req = make_requirements(
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let id = compute_channel_id(&cfg, 84532);
+        assert_eq!(
+            validate_channel_config(&cfg, id, &req, 84532),
+            Err(err::ERR_RECEIVER_MISMATCH)
+        );
+    }
+
+    #[test]
+    fn validate_channel_config_detects_zero_authorizer() {
+        let cfg = make_config(
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000002",
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let req = make_requirements(
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let id = compute_channel_id(&cfg, 84532);
+        // Zero `receiver_authorizer` in requirements is treated as missing.
+        assert_eq!(
+            validate_channel_config(&cfg, id, &req, 84532),
+            Err(err::ERR_RECEIVER_AUTHORIZER_MISMATCH)
+        );
+    }
+
+    #[test]
+    fn validate_channel_config_detects_token_mismatch() {
+        let cfg = make_config(
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000002",
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000099",
+            900,
+        );
+        let req = make_requirements(
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let id = compute_channel_id(&cfg, 84532);
+        assert_eq!(
+            validate_channel_config(&cfg, id, &req, 84532),
+            Err(err::ERR_TOKEN_MISMATCH)
+        );
+    }
+
+    #[test]
+    fn validate_channel_config_detects_withdraw_delay_mismatch() {
+        let cfg = make_config(
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000002",
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            1_800,
+        );
+        let req = make_requirements(
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            900,
+        );
+        let id = compute_channel_id(&cfg, 84532);
+        assert_eq!(
+            validate_channel_config(&cfg, id, &req, 84532),
+            Err(err::ERR_WITHDRAW_DELAY_MISMATCH)
+        );
+    }
+
+    #[test]
+    fn validate_channel_config_detects_withdraw_delay_out_of_range() {
+        let cfg = make_config(
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000002",
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            60, // below MIN_WITHDRAW_DELAY (900 s)
+        );
+        let req = make_requirements(
+            "0x0000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000005",
+            60,
+        );
+        let id = compute_channel_id(&cfg, 84532);
+        assert_eq!(
+            validate_channel_config(&cfg, id, &req, 84532),
+            Err(err::ERR_WITHDRAW_DELAY_OUT_OF_RANGE)
+        );
+    }
+
+    #[test]
+    fn erc3009_authorization_time_check_expired() {
+        let now = UnixTimestamp::now().as_secs();
+        let reason = erc3009_authorization_time_invalid_reason(
+            U256::ZERO,
+            U256::from(now.saturating_sub(1)),
+        );
+        assert_eq!(reason, Some(err::ERR_VALID_BEFORE_EXPIRED));
+    }
+
+    #[test]
+    fn erc3009_authorization_time_check_future_valid_after() {
+        let now = UnixTimestamp::now().as_secs();
+        let reason = erc3009_authorization_time_invalid_reason(
+            U256::from(now + 600),
+            U256::from(now + 1_000),
+        );
+        assert_eq!(reason, Some(err::ERR_VALID_AFTER_IN_FUTURE));
+    }
+
+    #[test]
+    fn erc3009_authorization_time_check_ok() {
+        let now = UnixTimestamp::now().as_secs();
+        let reason = erc3009_authorization_time_invalid_reason(
+            U256::from(now.saturating_sub(10)),
+            U256::from(now + 600),
+        );
+        assert_eq!(reason, None);
+    }
+}

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/verify.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/verify.rs
@@ -5,25 +5,35 @@
 //! a [`BatchSettlementVerifyResponse`] carrying the onchain channel snapshot
 //! on success or a canonical error code on failure.
 
-use alloy_primitives::{Address, U128, U256};
+use alloy_primitives::{Address, Bytes, U128, U256};
 use alloy_provider::Provider;
-use alloy_sol_types::{SolStruct, eip712_domain};
+use alloy_rpc_types_eth::TransactionRequest;
+use alloy_sol_types::{SolCall, SolStruct, eip712_domain};
 
-use super::abi::{IERC20View, ReceiveWithAuthorization};
+use super::abi::{
+    DepositWitness, IERC20View, PermitWitnessTransferFrom, ReceiveWithAuthorization,
+    TokenPermissions, X402BatchSettlement::depositCall,
+};
 use super::response::{BatchSettlementVerifyExtra, BatchSettlementVerifyResponse};
 use super::utils::{
-    erc3009_authorization_time_invalid_reason, read_channel_state, validate_channel_config,
+    erc3009_authorization_time_invalid_reason, read_channel_state, to_abi_channel_config,
+    validate_channel_config,
 };
-use super::voucher::{verify_signature_against_signer, verify_voucher_signature};
+use super::voucher::{
+    VoucherVerifyError, verify_signature_against_signer, verify_voucher_signature,
+};
+use crate::chain::permit2::PERMIT2_ADDRESS;
 use crate::v2_eip155_batch_settlement::constants::{
-    ERC3009_DEPOSIT_COLLECTOR_ADDRESS, PERMIT2_DEPOSIT_COLLECTOR_ADDRESS,
+    BATCH_SETTLEMENT_ADDRESS, ERC3009_DEPOSIT_COLLECTOR_ADDRESS, PERMIT2_DEPOSIT_COLLECTOR_ADDRESS,
 };
-use crate::v2_eip155_batch_settlement::encoding::build_erc3009_deposit_nonce;
+use crate::v2_eip155_batch_settlement::encoding::{
+    build_erc3009_collector_data, build_erc3009_deposit_nonce, build_permit2_collector_data,
+};
 use crate::v2_eip155_batch_settlement::errors as err;
 use crate::v2_eip155_batch_settlement::types::{
-    BatchSettlementPayload, BatchSettlementRefundPayload, ChannelConfig, DepositAuthorization,
-    DepositPayload, Erc3009Authorization, PaymentPayload, PaymentRequirements,
-    Permit2Authorization, VoucherFields, VoucherPayload,
+    AssetTransferMethod, BatchSettlementPayload, BatchSettlementRefundPayload, ChannelConfig,
+    DepositAuthorization, DepositPayload, Erc3009Authorization, PaymentPayload,
+    PaymentRequirements, Permit2Authorization, RefundPayload, VoucherFields, VoucherPayload,
 };
 
 /// Top-level dispatcher.
@@ -47,8 +57,11 @@ where
         BatchSettlementPayload::Voucher(voucher_payload) => {
             verify_voucher_payload(provider, chain_id, voucher_payload, requirements).await
         }
-        BatchSettlementPayload::Refund(refund) => {
+        BatchSettlementPayload::Refund(BatchSettlementRefundPayload::Client(refund)) => {
             verify_refund(provider, chain_id, refund, requirements).await
+        }
+        BatchSettlementPayload::Refund(BatchSettlementRefundPayload::Enriched(_)) => {
+            BatchSettlementVerifyResponse::invalid(None, err::ERR_INVALID_PAYLOAD_TYPE)
         }
         BatchSettlementPayload::Claim(_) | BatchSettlementPayload::Settle(_) => {
             BatchSettlementVerifyResponse::invalid(None, err::ERR_INVALID_PAYLOAD_TYPE)
@@ -79,7 +92,7 @@ where
 async fn verify_refund<P>(
     provider: &P,
     chain_id: u64,
-    refund: &BatchSettlementRefundPayload,
+    refund: &RefundPayload,
     requirements: &PaymentRequirements,
 ) -> BatchSettlementVerifyResponse
 where
@@ -88,8 +101,8 @@ where
     verify_voucher_or_refund(
         provider,
         chain_id,
-        refund.channel_config(),
-        refund.voucher(),
+        &refund.channel_config,
+        &refund.voucher,
         requirements,
         /* is_refund = */ true,
     )
@@ -145,8 +158,10 @@ where
         );
     }
 
-    // Spec rule 10: refund vouchers may equal `totalClaimed` (zero-charge);
-    // all other payloads must strictly exceed it.
+    // Spec rule 10 for voucher verification: refund vouchers may equal
+    // `totalClaimed` (zero-charge); ordinary voucher payments must strictly
+    // exceed it. Deposit verification is handled separately below and follows
+    // the Go reference by allowing equality for balance-only top-ups.
     let below_claimed = if is_refund {
         max_claimable < state.total_claimed
     } else {
@@ -186,6 +201,11 @@ where
         return BatchSettlementVerifyResponse::invalid(Some(payer), reason);
     }
 
+    let deposit_amount_u128 = match deposit_amount_to_u128(payload.deposit.amount.0) {
+        Ok(amount) => amount,
+        Err(reason) => return BatchSettlementVerifyResponse::invalid(Some(payer), reason),
+    };
+
     if let Err(reason) =
         verify_deposit_authorization(provider, payload, requirements, chain_id).await
     {
@@ -221,12 +241,6 @@ where
         return BatchSettlementVerifyResponse::invalid(Some(payer), err::ERR_INSUFFICIENT_BALANCE);
     }
 
-    let Some(deposit_amount_u128) = u256_to_u128(payload.deposit.amount.0) else {
-        return BatchSettlementVerifyResponse::invalid(
-            Some(payer),
-            err::ERR_CUMULATIVE_EXCEEDS_BALANCE,
-        );
-    };
     let effective_balance = state.balance.saturating_add(deposit_amount_u128);
 
     let max_claimable = payload.voucher.max_claimable_amount.0;
@@ -236,16 +250,34 @@ where
             err::ERR_CUMULATIVE_EXCEEDS_BALANCE,
         );
     }
-    if max_claimable <= state.total_claimed {
+    // Deposit top-ups may carry the current cumulative voucher without
+    // charging a new request. Match the Go reference: reject only values below
+    // the already-claimed total, not equality.
+    if max_claimable < state.total_claimed {
         return BatchSettlementVerifyResponse::invalid(
             Some(payer),
             err::ERR_CUMULATIVE_AMOUNT_BELOW_CLAIMED,
         );
     }
 
+    let calldata = build_deposit_calldata(payload, deposit_amount_u128);
+    if let Err(message) = simulate_batch_settlement_call(provider, calldata).await {
+        return BatchSettlementVerifyResponse::invalid_with_message(
+            Some(payer),
+            err::ERR_DEPOSIT_SIMULATION_FAILED,
+            message,
+        );
+    }
+
     BatchSettlementVerifyResponse::valid(
         payer,
-        BatchSettlementVerifyExtra::from_state(payload.voucher.channel_id, &state),
+        BatchSettlementVerifyExtra {
+            channel_id: payload.voucher.channel_id,
+            balance: effective_balance.into(),
+            total_claimed: state.total_claimed.into(),
+            withdraw_requested_at: state.withdraw_requested_at,
+            refund_nonce: state.refund_nonce.into(),
+        },
     )
 }
 
@@ -260,10 +292,16 @@ where
 {
     match &payload.deposit.authorization {
         DepositAuthorization::Erc3009(auth) => {
+            if requirements.extra.asset_transfer_method == Some(AssetTransferMethod::Permit2) {
+                return Err(err::ERR_PERMIT2_AUTHORIZATION_REQUIRED);
+            }
             verify_erc3009_authorization(provider, payload, auth, requirements, chain_id).await
         }
         DepositAuthorization::Permit2(auth) => {
-            verify_permit2_authorization(payload, auth, requirements)
+            if requirements.extra.asset_transfer_method == Some(AssetTransferMethod::Eip3009) {
+                return Err(err::ERR_ERC3009_AUTHORIZATION_REQUIRED);
+            }
+            verify_permit2_authorization(provider, payload, auth, requirements, chain_id).await
         }
     }
 }
@@ -311,30 +349,32 @@ where
     };
     let digest = receive_auth.eip712_signing_hash(&domain);
 
-    match verify_signature_against_signer(
+    match verify_token_authorization_signature(
         provider,
         &auth.signature,
         &digest,
-        payer_addr,
-        // ERC-3009 signers are the payer EOA itself; smart-wallet payers
-        // fall through to EIP-1271 against `payer`.
-        payer_addr,
+        &payload.channel_config,
     )
     .await
     {
         Ok(()) => Ok(()),
-        Err(_) => Err(err::ERR_INVALID_RECEIVE_AUTHORIZATION_SIGNATURE),
+        Err(e) => Err(erc3009_authorization_signature_error_reason(e)),
     }
 }
 
-fn verify_permit2_authorization(
+async fn verify_permit2_authorization<P>(
+    provider: &P,
     payload: &DepositPayload,
     auth: &Permit2Authorization,
     requirements: &PaymentRequirements,
-) -> Result<(), &'static str> {
+    chain_id: u64,
+) -> Result<(), &'static str>
+where
+    P: Provider,
+{
     let payer: Address = payload.channel_config.payer.into();
     if Address::from(auth.from) != payer {
-        return Err(err::ERR_PERMIT2_INVALID_SIGNATURE);
+        return Err(err::ERR_DEPOSIT_PAYLOAD);
     }
     if Address::from(auth.spender) != PERMIT2_DEPOSIT_COLLECTOR_ADDRESS {
         return Err(err::ERR_PERMIT2_INVALID_SPENDER);
@@ -343,6 +383,8 @@ fn verify_permit2_authorization(
     if Address::from(auth.permitted.token) != asset {
         return Err(err::ERR_TOKEN_MISMATCH);
     }
+    // The Permit2 collector pulls exactly `deposit.amount`; require the
+    // signed permission to bind that same amount rather than a wider cap.
     if auth.permitted.amount.0 != payload.deposit.amount.0 {
         return Err(err::ERR_PERMIT2_AMOUNT_MISMATCH);
     }
@@ -354,11 +396,151 @@ fn verify_permit2_authorization(
     if auth.deadline.0 < now_u256 + U256::from(6u64) {
         return Err(err::ERR_PERMIT2_DEADLINE_EXPIRED);
     }
-    // Note: the EIP-712 typed-data signature over the Permit2
-    // `PermitWitnessTransferFrom` is verified onchain by `Permit2` itself
-    // when the deposit collector relays it. We surface only the structural
-    // checks here; signature verification happens during deposit simulation.
+
+    let permit = PermitWitnessTransferFrom {
+        permitted: TokenPermissions {
+            token: asset,
+            amount: payload.deposit.amount.0,
+        },
+        spender: auth.spender.into(),
+        nonce: auth.nonce.0,
+        deadline: auth.deadline.0,
+        witness: DepositWitness {
+            channelId: payload.voucher.channel_id,
+        },
+    };
+    let domain = eip712_domain! {
+        name: "Permit2",
+        chain_id: chain_id,
+        verifying_contract: PERMIT2_ADDRESS,
+    };
+    let digest = permit.eip712_signing_hash(&domain);
+    verify_token_authorization_signature(
+        provider,
+        &auth.signature,
+        &digest,
+        &payload.channel_config,
+    )
+    .await
+    .map_err(permit2_authorization_signature_error_reason)?;
+
+    let token_contract = IERC20View::new(asset, provider);
+    let allowance = token_contract
+        .allowance(payer, PERMIT2_ADDRESS)
+        .call()
+        .await
+        .map_err(|_| err::ERR_RPC_READ_FAILED)?;
+    if allowance < payload.deposit.amount.0 {
+        return Err(err::ERR_PERMIT2_ALLOWANCE_REQUIRED);
+    }
+
     Ok(())
+}
+
+async fn verify_token_authorization_signature<P>(
+    provider: &P,
+    signature: &[u8],
+    digest: &alloy_primitives::B256,
+    channel_config: &ChannelConfig,
+) -> Result<(), VoucherVerifyError>
+where
+    P: Provider,
+{
+    let payer: Address = channel_config.payer.into();
+    let payer_authorizer: Address = channel_config.payer_authorizer.into();
+    if payer_authorizer == Address::ZERO {
+        // `payerAuthorizer == address(0)` is the scheme's smart-wallet mode:
+        // vouchers and token-transfer authorizations are validated through
+        // EIP-1271 against the payer contract.
+        return verify_signature_against_signer(provider, signature, digest, payer, Address::ZERO)
+            .await;
+    }
+
+    // Permit2 and ERC-3009 token-transfer authorizations are signed by the
+    // token owner (`payer`), not the channel's voucher authorizer.
+    let ecdsa_result =
+        verify_signature_against_signer(provider, signature, digest, payer, payer).await;
+    if ecdsa_result.is_ok() {
+        return ecdsa_result;
+    }
+
+    // Hybrid mode: the payer can still be a smart-wallet contract while a
+    // separate non-zero payerAuthorizer signs vouchers. In that case the token
+    // authorization itself is validated by the payer contract via EIP-1271.
+    let code = provider
+        .get_code_at(payer)
+        .into_future()
+        .await
+        .map_err(|_| VoucherVerifyError::RpcReadFailed)?;
+    if code.is_empty() {
+        return ecdsa_result;
+    }
+
+    verify_signature_against_signer(provider, signature, digest, payer, Address::ZERO).await
+}
+
+fn erc3009_authorization_signature_error_reason(error: VoucherVerifyError) -> &'static str {
+    match error {
+        VoucherVerifyError::RpcReadFailed => err::ERR_RPC_READ_FAILED,
+        VoucherVerifyError::InvalidFormat | VoucherVerifyError::InvalidSignature => {
+            err::ERR_INVALID_RECEIVE_AUTHORIZATION_SIGNATURE
+        }
+    }
+}
+
+fn permit2_authorization_signature_error_reason(error: VoucherVerifyError) -> &'static str {
+    match error {
+        VoucherVerifyError::RpcReadFailed => err::ERR_RPC_READ_FAILED,
+        VoucherVerifyError::InvalidFormat | VoucherVerifyError::InvalidSignature => {
+            err::ERR_PERMIT2_INVALID_SIGNATURE
+        }
+    }
+}
+
+fn build_deposit_calldata(payload: &DepositPayload, deposit_amount: U128) -> Bytes {
+    let (collector, collector_data) = match &payload.deposit.authorization {
+        DepositAuthorization::Erc3009(auth) => (
+            ERC3009_DEPOSIT_COLLECTOR_ADDRESS,
+            build_erc3009_collector_data(
+                auth.valid_after.0,
+                auth.valid_before.0,
+                auth.salt,
+                &auth.signature,
+            ),
+        ),
+        DepositAuthorization::Permit2(auth) => (
+            PERMIT2_DEPOSIT_COLLECTOR_ADDRESS,
+            build_permit2_collector_data(
+                auth.nonce.0,
+                auth.deadline.0,
+                &auth.signature,
+                &Bytes::new(),
+            ),
+        ),
+    };
+
+    depositCall {
+        config: to_abi_channel_config(&payload.channel_config),
+        amount: deposit_amount.to::<u128>(),
+        collector,
+        collectorData: collector_data,
+    }
+    .abi_encode()
+    .into()
+}
+
+async fn simulate_batch_settlement_call<P>(provider: &P, calldata: Bytes) -> Result<(), String>
+where
+    P: Provider,
+{
+    let request = TransactionRequest::default()
+        .input(calldata.into())
+        .to(BATCH_SETTLEMENT_ADDRESS);
+    provider
+        .call(request)
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }
 
 /// Converts a `U256` to `U128`, returning `None` when the value overflows.
@@ -370,6 +552,13 @@ fn u256_to_u128(value: U256) -> Option<U128> {
     let mut narrow = [0u8; 16];
     narrow.copy_from_slice(&bytes[16..]);
     Some(U128::from_be_bytes(narrow))
+}
+
+fn deposit_amount_to_u128(value: U256) -> Result<U128, &'static str> {
+    if value == U256::ZERO {
+        return Err(err::ERR_DEPOSIT_PAYLOAD);
+    }
+    u256_to_u128(value).ok_or(err::ERR_CUMULATIVE_EXCEEDS_BALANCE)
 }
 
 #[cfg(test)]
@@ -393,5 +582,46 @@ mod tests {
     fn u256_to_u128_returns_none_on_overflow() {
         let overflowed = U256::from(u128::MAX) + U256::from(1u64);
         assert_eq!(u256_to_u128(overflowed), None);
+    }
+
+    #[test]
+    fn deposit_amount_to_u128_rejects_zero() {
+        assert_eq!(
+            deposit_amount_to_u128(U256::ZERO),
+            Err(err::ERR_DEPOSIT_PAYLOAD)
+        );
+    }
+
+    #[test]
+    fn deposit_amount_to_u128_rejects_overflow() {
+        let overflowed = U256::from(u128::MAX) + U256::from(1u64);
+        assert_eq!(
+            deposit_amount_to_u128(overflowed),
+            Err(err::ERR_CUMULATIVE_EXCEEDS_BALANCE)
+        );
+    }
+
+    #[test]
+    fn token_authorization_error_mapping_preserves_rpc_errors() {
+        assert_eq!(
+            erc3009_authorization_signature_error_reason(VoucherVerifyError::RpcReadFailed),
+            err::ERR_RPC_READ_FAILED
+        );
+        assert_eq!(
+            permit2_authorization_signature_error_reason(VoucherVerifyError::RpcReadFailed),
+            err::ERR_RPC_READ_FAILED
+        );
+    }
+
+    #[test]
+    fn token_authorization_error_mapping_preserves_signature_errors() {
+        assert_eq!(
+            erc3009_authorization_signature_error_reason(VoucherVerifyError::InvalidSignature),
+            err::ERR_INVALID_RECEIVE_AUTHORIZATION_SIGNATURE
+        );
+        assert_eq!(
+            permit2_authorization_signature_error_reason(VoucherVerifyError::InvalidFormat),
+            err::ERR_PERMIT2_INVALID_SIGNATURE
+        );
     }
 }

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/verify.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/verify.rs
@@ -1,0 +1,397 @@
+//! Verify dispatcher for the batch-settlement scheme.
+//!
+//! Routes incoming verify requests to the right handler based on the payload
+//! `type` discriminator: `deposit` / `voucher` / `refund`. Each handler returns
+//! a [`BatchSettlementVerifyResponse`] carrying the onchain channel snapshot
+//! on success or a canonical error code on failure.
+
+use alloy_primitives::{Address, U128, U256};
+use alloy_provider::Provider;
+use alloy_sol_types::{SolStruct, eip712_domain};
+
+use super::abi::{IERC20View, ReceiveWithAuthorization};
+use super::response::{BatchSettlementVerifyExtra, BatchSettlementVerifyResponse};
+use super::utils::{
+    erc3009_authorization_time_invalid_reason, read_channel_state, validate_channel_config,
+};
+use super::voucher::{verify_signature_against_signer, verify_voucher_signature};
+use crate::v2_eip155_batch_settlement::constants::{
+    ERC3009_DEPOSIT_COLLECTOR_ADDRESS, PERMIT2_DEPOSIT_COLLECTOR_ADDRESS,
+};
+use crate::v2_eip155_batch_settlement::encoding::build_erc3009_deposit_nonce;
+use crate::v2_eip155_batch_settlement::errors as err;
+use crate::v2_eip155_batch_settlement::types::{
+    BatchSettlementPayload, BatchSettlementRefundPayload, ChannelConfig, DepositAuthorization,
+    DepositPayload, Erc3009Authorization, PaymentPayload, PaymentRequirements,
+    Permit2Authorization, VoucherFields, VoucherPayload,
+};
+
+/// Top-level dispatcher.
+pub async fn verify<P>(
+    provider: &P,
+    chain_id: u64,
+    payment_payload: &PaymentPayload,
+    requirements: &PaymentRequirements,
+) -> BatchSettlementVerifyResponse
+where
+    P: Provider,
+{
+    if payment_payload.accepted.network != requirements.network {
+        return BatchSettlementVerifyResponse::invalid(None, err::ERR_NETWORK_MISMATCH);
+    }
+
+    match &payment_payload.payload {
+        BatchSettlementPayload::Deposit(deposit) => {
+            verify_deposit(provider, chain_id, deposit, requirements).await
+        }
+        BatchSettlementPayload::Voucher(voucher_payload) => {
+            verify_voucher_payload(provider, chain_id, voucher_payload, requirements).await
+        }
+        BatchSettlementPayload::Refund(refund) => {
+            verify_refund(provider, chain_id, refund, requirements).await
+        }
+        BatchSettlementPayload::Claim(_) | BatchSettlementPayload::Settle(_) => {
+            BatchSettlementVerifyResponse::invalid(None, err::ERR_INVALID_PAYLOAD_TYPE)
+        }
+    }
+}
+
+async fn verify_voucher_payload<P>(
+    provider: &P,
+    chain_id: u64,
+    payload: &VoucherPayload,
+    requirements: &PaymentRequirements,
+) -> BatchSettlementVerifyResponse
+where
+    P: Provider,
+{
+    verify_voucher_or_refund(
+        provider,
+        chain_id,
+        &payload.channel_config,
+        &payload.voucher,
+        requirements,
+        /* is_refund = */ false,
+    )
+    .await
+}
+
+async fn verify_refund<P>(
+    provider: &P,
+    chain_id: u64,
+    refund: &BatchSettlementRefundPayload,
+    requirements: &PaymentRequirements,
+) -> BatchSettlementVerifyResponse
+where
+    P: Provider,
+{
+    verify_voucher_or_refund(
+        provider,
+        chain_id,
+        refund.channel_config(),
+        refund.voucher(),
+        requirements,
+        /* is_refund = */ true,
+    )
+    .await
+}
+
+async fn verify_voucher_or_refund<P>(
+    provider: &P,
+    chain_id: u64,
+    channel_config: &ChannelConfig,
+    voucher: &VoucherFields,
+    requirements: &PaymentRequirements,
+    is_refund: bool,
+) -> BatchSettlementVerifyResponse
+where
+    P: Provider,
+{
+    let payer_addr: Address = channel_config.payer.into();
+    let payer = payer_addr.to_checksum(None);
+
+    if let Err(reason) =
+        validate_channel_config(channel_config, voucher.channel_id, requirements, chain_id)
+    {
+        return BatchSettlementVerifyResponse::invalid(Some(payer), reason);
+    }
+
+    if let Err(e) = verify_voucher_signature(
+        provider,
+        voucher,
+        payer_addr,
+        channel_config.payer_authorizer.into(),
+        chain_id,
+    )
+    .await
+    {
+        return BatchSettlementVerifyResponse::invalid(Some(payer), e.as_error_code());
+    }
+
+    let state = match read_channel_state(provider, voucher.channel_id).await {
+        Ok(state) => state,
+        Err(reason) => return BatchSettlementVerifyResponse::invalid(Some(payer), reason),
+    };
+
+    if state.is_empty() {
+        return BatchSettlementVerifyResponse::invalid(Some(payer), err::ERR_CHANNEL_NOT_FOUND);
+    }
+
+    let max_claimable = voucher.max_claimable_amount.0;
+    if max_claimable > state.balance {
+        return BatchSettlementVerifyResponse::invalid(
+            Some(payer),
+            err::ERR_CUMULATIVE_EXCEEDS_BALANCE,
+        );
+    }
+
+    // Spec rule 10: refund vouchers may equal `totalClaimed` (zero-charge);
+    // all other payloads must strictly exceed it.
+    let below_claimed = if is_refund {
+        max_claimable < state.total_claimed
+    } else {
+        max_claimable <= state.total_claimed
+    };
+    if below_claimed {
+        return BatchSettlementVerifyResponse::invalid(
+            Some(payer),
+            err::ERR_CUMULATIVE_AMOUNT_BELOW_CLAIMED,
+        );
+    }
+
+    BatchSettlementVerifyResponse::valid(
+        payer,
+        BatchSettlementVerifyExtra::from_state(voucher.channel_id, &state),
+    )
+}
+
+async fn verify_deposit<P>(
+    provider: &P,
+    chain_id: u64,
+    payload: &DepositPayload,
+    requirements: &PaymentRequirements,
+) -> BatchSettlementVerifyResponse
+where
+    P: Provider,
+{
+    let payer_addr: Address = payload.channel_config.payer.into();
+    let payer = payer_addr.to_checksum(None);
+
+    if let Err(reason) = validate_channel_config(
+        &payload.channel_config,
+        payload.voucher.channel_id,
+        requirements,
+        chain_id,
+    ) {
+        return BatchSettlementVerifyResponse::invalid(Some(payer), reason);
+    }
+
+    if let Err(reason) =
+        verify_deposit_authorization(provider, payload, requirements, chain_id).await
+    {
+        return BatchSettlementVerifyResponse::invalid(Some(payer), reason);
+    }
+
+    if let Err(e) = verify_voucher_signature(
+        provider,
+        &payload.voucher,
+        payer_addr,
+        payload.channel_config.payer_authorizer.into(),
+        chain_id,
+    )
+    .await
+    {
+        return BatchSettlementVerifyResponse::invalid(Some(payer), e.as_error_code());
+    }
+
+    let state = match read_channel_state(provider, payload.voucher.channel_id).await {
+        Ok(state) => state,
+        Err(reason) => return BatchSettlementVerifyResponse::invalid(Some(payer), reason),
+    };
+
+    let asset_addr: Address = requirements.asset.into();
+    let token_contract = IERC20View::new(asset_addr, provider);
+    let payer_balance = match token_contract.balanceOf(payer_addr).call().await {
+        Ok(b) => b,
+        Err(_) => {
+            return BatchSettlementVerifyResponse::invalid(Some(payer), err::ERR_RPC_READ_FAILED);
+        }
+    };
+    if payer_balance < payload.deposit.amount.0 {
+        return BatchSettlementVerifyResponse::invalid(Some(payer), err::ERR_INSUFFICIENT_BALANCE);
+    }
+
+    let Some(deposit_amount_u128) = u256_to_u128(payload.deposit.amount.0) else {
+        return BatchSettlementVerifyResponse::invalid(
+            Some(payer),
+            err::ERR_CUMULATIVE_EXCEEDS_BALANCE,
+        );
+    };
+    let effective_balance = state.balance.saturating_add(deposit_amount_u128);
+
+    let max_claimable = payload.voucher.max_claimable_amount.0;
+    if max_claimable > effective_balance {
+        return BatchSettlementVerifyResponse::invalid(
+            Some(payer),
+            err::ERR_CUMULATIVE_EXCEEDS_BALANCE,
+        );
+    }
+    if max_claimable <= state.total_claimed {
+        return BatchSettlementVerifyResponse::invalid(
+            Some(payer),
+            err::ERR_CUMULATIVE_AMOUNT_BELOW_CLAIMED,
+        );
+    }
+
+    BatchSettlementVerifyResponse::valid(
+        payer,
+        BatchSettlementVerifyExtra::from_state(payload.voucher.channel_id, &state),
+    )
+}
+
+async fn verify_deposit_authorization<P>(
+    provider: &P,
+    payload: &DepositPayload,
+    requirements: &PaymentRequirements,
+    chain_id: u64,
+) -> Result<(), &'static str>
+where
+    P: Provider,
+{
+    match &payload.deposit.authorization {
+        DepositAuthorization::Erc3009(auth) => {
+            verify_erc3009_authorization(provider, payload, auth, requirements, chain_id).await
+        }
+        DepositAuthorization::Permit2(auth) => {
+            verify_permit2_authorization(payload, auth, requirements)
+        }
+    }
+}
+
+async fn verify_erc3009_authorization<P>(
+    provider: &P,
+    payload: &DepositPayload,
+    auth: &Erc3009Authorization,
+    requirements: &PaymentRequirements,
+    chain_id: u64,
+) -> Result<(), &'static str>
+where
+    P: Provider,
+{
+    if requirements.extra.name.is_empty() || requirements.extra.version.is_empty() {
+        return Err(err::ERR_MISSING_EIP712_DOMAIN);
+    }
+
+    let valid_after = auth.valid_after.0;
+    let valid_before = auth.valid_before.0;
+    if let Some(reason) = erc3009_authorization_time_invalid_reason(valid_after, valid_before) {
+        return Err(reason);
+    }
+
+    // The nonce binds the ERC-3009 authorization to (channelId, salt): two
+    // deposits to the same channel must use distinct salts to avoid nonce
+    // collisions onchain.
+    let erc3009_nonce = build_erc3009_deposit_nonce(payload.voucher.channel_id, auth.salt);
+
+    let token_addr: Address = requirements.asset.into();
+    let payer_addr: Address = payload.channel_config.payer.into();
+    let receive_auth = ReceiveWithAuthorization {
+        from: payer_addr,
+        to: ERC3009_DEPOSIT_COLLECTOR_ADDRESS,
+        value: payload.deposit.amount.0,
+        validAfter: valid_after,
+        validBefore: valid_before,
+        nonce: erc3009_nonce,
+    };
+    let domain = eip712_domain! {
+        name: requirements.extra.name.clone(),
+        version: requirements.extra.version.clone(),
+        chain_id: chain_id,
+        verifying_contract: token_addr,
+    };
+    let digest = receive_auth.eip712_signing_hash(&domain);
+
+    match verify_signature_against_signer(
+        provider,
+        &auth.signature,
+        &digest,
+        payer_addr,
+        // ERC-3009 signers are the payer EOA itself; smart-wallet payers
+        // fall through to EIP-1271 against `payer`.
+        payer_addr,
+    )
+    .await
+    {
+        Ok(()) => Ok(()),
+        Err(_) => Err(err::ERR_INVALID_RECEIVE_AUTHORIZATION_SIGNATURE),
+    }
+}
+
+fn verify_permit2_authorization(
+    payload: &DepositPayload,
+    auth: &Permit2Authorization,
+    requirements: &PaymentRequirements,
+) -> Result<(), &'static str> {
+    let payer: Address = payload.channel_config.payer.into();
+    if Address::from(auth.from) != payer {
+        return Err(err::ERR_PERMIT2_INVALID_SIGNATURE);
+    }
+    if Address::from(auth.spender) != PERMIT2_DEPOSIT_COLLECTOR_ADDRESS {
+        return Err(err::ERR_PERMIT2_INVALID_SPENDER);
+    }
+    let asset: Address = requirements.asset.into();
+    if Address::from(auth.permitted.token) != asset {
+        return Err(err::ERR_TOKEN_MISMATCH);
+    }
+    if auth.permitted.amount.0 != payload.deposit.amount.0 {
+        return Err(err::ERR_PERMIT2_AMOUNT_MISMATCH);
+    }
+    if auth.witness.channel_id != payload.voucher.channel_id {
+        return Err(err::ERR_CHANNEL_ID_MISMATCH);
+    }
+    let now = x402_types::timestamp::UnixTimestamp::now().as_secs();
+    let now_u256 = U256::from(now);
+    if auth.deadline.0 < now_u256 + U256::from(6u64) {
+        return Err(err::ERR_PERMIT2_DEADLINE_EXPIRED);
+    }
+    // Note: the EIP-712 typed-data signature over the Permit2
+    // `PermitWitnessTransferFrom` is verified onchain by `Permit2` itself
+    // when the deposit collector relays it. We surface only the structural
+    // checks here; signature verification happens during deposit simulation.
+    Ok(())
+}
+
+/// Converts a `U256` to `U128`, returning `None` when the value overflows.
+fn u256_to_u128(value: U256) -> Option<U128> {
+    let bytes: [u8; 32] = value.to_be_bytes();
+    if bytes[..16].iter().any(|b| *b != 0) {
+        return None;
+    }
+    let mut narrow = [0u8; 16];
+    narrow.copy_from_slice(&bytes[16..]);
+    Some(U128::from_be_bytes(narrow))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn u256_to_u128_round_trips_small_values() {
+        assert_eq!(u256_to_u128(U256::ZERO), Some(U128::ZERO));
+        assert_eq!(
+            u256_to_u128(U256::from(1_000u64)),
+            Some(U128::from(1_000u128))
+        );
+        assert_eq!(
+            u256_to_u128(U256::from(u128::MAX)),
+            Some(U128::from(u128::MAX))
+        );
+    }
+
+    #[test]
+    fn u256_to_u128_returns_none_on_overflow() {
+        let overflowed = U256::from(u128::MAX) + U256::from(1u64);
+        assert_eq!(u256_to_u128(overflowed), None);
+    }
+}

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/verify.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/verify.rs
@@ -564,6 +564,9 @@ fn deposit_amount_to_u128(value: U256) -> Result<U128, &'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::{B256, b256, keccak256};
+
+    use crate::v2_eip155_batch_settlement::types::DepositSegment;
 
     #[test]
     fn u256_to_u128_round_trips_small_values() {
@@ -622,6 +625,60 @@ mod tests {
         assert_eq!(
             permit2_authorization_signature_error_reason(VoucherVerifyError::InvalidFormat),
             err::ERR_PERMIT2_INVALID_SIGNATURE
+        );
+    }
+
+    #[test]
+    fn erc3009_deposit_calldata_matches_typescript_reference() {
+        // Fixture generated from the canonical x402 TypeScript implementation:
+        // buildErc3009CollectorData uses viem encodeAbiParameters, then
+        // x402BatchSettlement.deposit((...),uint128,address,bytes) encodes
+        // with selector 0x140f1e75.
+        let payload = DepositPayload {
+            channel_config: ChannelConfig {
+                payer: "0x57b0eF875DeB5A37301F1640E469a2129Da9490E"
+                    .parse()
+                    .unwrap(),
+                payer_authorizer: "0x57b0eF875DeB5A37301F1640E469a2129Da9490E"
+                    .parse()
+                    .unwrap(),
+                receiver: "0x2707390BC2E69FF9637106b6a43Cc85183392c6A"
+                    .parse()
+                    .unwrap(),
+                receiver_authorizer: "0x2707390BC2E69FF9637106b6a43Cc85183392c6A"
+                    .parse()
+                    .unwrap(),
+                token: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+                    .parse()
+                    .unwrap(),
+                withdraw_delay: 900,
+                salt: B256::ZERO,
+            },
+            voucher: VoucherFields {
+                channel_id: B256::ZERO,
+                max_claimable_amount: U128::from(10_000u128).into(),
+                signature: Bytes::from(vec![0x11; 65]),
+            },
+            deposit: DepositSegment {
+                amount: U256::from(100_000u64).into(),
+                authorization: DepositAuthorization::Erc3009(Erc3009Authorization {
+                    valid_after: U256::ZERO.into(),
+                    valid_before: U256::from(1_782_471_206u64).into(),
+                    salt: b256!(
+                        "0x2222222222222222222222222222222222222222222222222222222222222222"
+                    ),
+                    signature: Bytes::from(vec![0x11; 65]),
+                }),
+            },
+        };
+
+        let calldata = build_deposit_calldata(&payload, U128::from(100_000u128));
+
+        assert_eq!(calldata.len(), 612);
+        assert_eq!(&calldata[..4], &[0x14, 0x0f, 0x1e, 0x75]);
+        assert_eq!(
+            keccak256(calldata.as_ref()),
+            b256!("0x597b162bcb662f450e0352297afdceabef1416829e1dfa26e42a9a86a4532a6c")
         );
     }
 }

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/voucher.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/facilitator/voucher.rs
@@ -1,0 +1,330 @@
+//! Voucher signature verification for the batch-settlement scheme.
+//!
+//! There are two verification paths:
+//!
+//! - **Plain ECDSA recovery** (the fast / RPC-free path). Used when the channel
+//!   was configured with a non-zero `payerAuthorizer`. The recovered signer
+//!   must equal that authorizer EOA.
+//! - **EIP-1271 fallback** (`isValidSignature`). Used when the channel was
+//!   configured with `payerAuthorizer == address(0)`, indicating a smart wallet
+//!   payer that signs vouchers through its contract.
+
+#[cfg(test)]
+use alloy_primitives::U128;
+use alloy_primitives::{Address, B256, Signature};
+use alloy_provider::Provider;
+use alloy_sol_types::{SolCall, sol};
+
+use super::utils::compute_voucher_digest;
+use crate::v1_eip155_exact::{StructuredSignature, StructuredSignatureFormatError};
+use crate::v2_eip155_batch_settlement::types::VoucherFields;
+
+sol! {
+    /// ERC-1271 `isValidSignature(bytes32, bytes)` — returns the 4-byte
+    /// magic value `0x1626ba7e` when the contract considers the signature valid.
+    function isValidSignature(bytes32 hash, bytes signature) external view returns (bytes4);
+}
+
+/// The 4-byte `bytes4(keccak256("isValidSignature(bytes32,bytes)"))` magic
+/// value returned by EIP-1271 wallets for valid signatures.
+pub const EIP1271_MAGIC_VALUE: [u8; 4] = [0x16, 0x26, 0xba, 0x7e];
+
+/// Reasons voucher verification can fail. Each variant maps 1:1 to a wire-format
+/// error code (see [`crate::v2_eip155_batch_settlement::errors`]) and ultimately
+/// to an `invalidReason` string on the `VerifyResponse`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VoucherVerifyError {
+    /// Signature bytes do not decode as a valid Ethereum signature.
+    InvalidFormat,
+    /// Signature did not recover to (or validate against) the expected signer.
+    InvalidSignature,
+    /// Onchain EIP-1271 lookup failed (RPC error).
+    RpcReadFailed,
+}
+
+impl VoucherVerifyError {
+    /// Maps to the scheme's wire-format error code string.
+    pub fn as_error_code(self) -> &'static str {
+        use crate::v2_eip155_batch_settlement::errors as err;
+        match self {
+            VoucherVerifyError::InvalidFormat => err::ERR_INVALID_VOUCHER_SIGNATURE,
+            VoucherVerifyError::InvalidSignature => err::ERR_INVALID_VOUCHER_SIGNATURE,
+            VoucherVerifyError::RpcReadFailed => err::ERR_RPC_READ_FAILED,
+        }
+    }
+}
+
+impl From<StructuredSignatureFormatError> for VoucherVerifyError {
+    fn from(_: StructuredSignatureFormatError) -> Self {
+        VoucherVerifyError::InvalidFormat
+    }
+}
+
+/// Computes the digest the voucher signer commits to and dispatches to either
+/// the ECDSA-recovery path or the EIP-1271 path based on the channel's
+/// `payerAuthorizer`.
+pub async fn verify_voucher_signature<P>(
+    provider: &P,
+    voucher: &VoucherFields,
+    payer: Address,
+    payer_authorizer: Address,
+    chain_id: u64,
+) -> Result<(), VoucherVerifyError>
+where
+    P: Provider,
+{
+    let digest =
+        compute_voucher_digest(voucher.channel_id, voucher.max_claimable_amount.0, chain_id);
+    verify_signature_against_signer(
+        provider,
+        &voucher.signature,
+        &digest,
+        payer,
+        payer_authorizer,
+    )
+    .await
+}
+
+/// Same as [`verify_voucher_signature`] but for arbitrary digests / signatures.
+///
+/// Used by the deposit verification path to check an ERC-3009
+/// `ReceiveWithAuthorization` signature, which obeys the same EOA-then-1271
+/// fallback rules as a voucher.
+pub async fn verify_signature_against_signer<P>(
+    provider: &P,
+    signature: &[u8],
+    digest: &B256,
+    payer: Address,
+    payer_authorizer: Address,
+) -> Result<(), VoucherVerifyError>
+where
+    P: Provider,
+{
+    if payer_authorizer != Address::ZERO {
+        recover_ecdsa_and_match(signature, digest, payer_authorizer)
+    } else {
+        verify_via_eip1271(provider, signature, digest, payer).await
+    }
+}
+
+/// Recovers an EOA signature and matches it against `expected_signer`.
+///
+/// Both 64-byte (ERC-2098 compact) and 65-byte canonical EIP-712 signatures
+/// are accepted, matching the upstream behaviour. Smart-wallet wrapped
+/// signatures (EIP-6492) are rejected on the ECDSA path; those are reserved
+/// for the EIP-1271 fallback.
+fn recover_ecdsa_and_match(
+    signature: &[u8],
+    digest: &B256,
+    expected_signer: Address,
+) -> Result<(), VoucherVerifyError> {
+    let normalized: Option<Signature> = match signature.len() {
+        65 => Signature::from_raw(signature)
+            .ok()
+            .map(|s| s.normalized_s()),
+        64 => Some(Signature::from_erc2098(signature).normalized_s()),
+        _ => None,
+    };
+    let signature = normalized.ok_or(VoucherVerifyError::InvalidFormat)?;
+    let recovered = signature
+        .recover_address_from_prehash(digest)
+        .map_err(|_| VoucherVerifyError::InvalidSignature)?;
+    if recovered == expected_signer {
+        Ok(())
+    } else {
+        Err(VoucherVerifyError::InvalidSignature)
+    }
+}
+
+/// Verifies a signature against a deployed EIP-1271 smart wallet at `payer`.
+async fn verify_via_eip1271<P>(
+    provider: &P,
+    signature: &[u8],
+    digest: &B256,
+    payer: Address,
+) -> Result<(), VoucherVerifyError>
+where
+    P: Provider,
+{
+    // For counterfactual wallets, the signature may be wrapped in EIP-6492.
+    // We use the same parser as the v1 exact scheme to unwrap the inner
+    // signature, then call `isValidSignature` against the (already-deployed)
+    // wallet contract. Counterfactual deployment is out of scope for
+    // batch-settlement voucher verification: vouchers are issued in the
+    // steady state, after the wallet is deployed via the initial deposit.
+    let structured = StructuredSignature::try_from_bytes(signature.to_vec().into(), payer, digest)?;
+
+    let inner = match structured {
+        StructuredSignature::EOA(_) => {
+            // Channel config says the voucher signer is `payer` itself, but
+            // the signature recovers to an EOA — treat that as a smart-wallet
+            // contract that happens to be at `payer`. Pass the original bytes
+            // unchanged to `isValidSignature`.
+            signature.to_vec().into()
+        }
+        StructuredSignature::EIP1271(bytes) => bytes,
+        StructuredSignature::EIP6492 { inner, .. } => inner,
+    };
+
+    let call = isValidSignatureCall {
+        hash: *digest,
+        signature: inner,
+    };
+    let calldata = call.abi_encode();
+    let request = alloy_rpc_types_eth::TransactionRequest::default()
+        .input(calldata.into())
+        .to(payer);
+
+    let raw = provider
+        .call(request)
+        .await
+        .map_err(|_| VoucherVerifyError::RpcReadFailed)?;
+
+    if raw.len() < 32 {
+        return Err(VoucherVerifyError::InvalidSignature);
+    }
+    // The ABI return value for `bytes4` is right-padded to 32 bytes; the
+    // first 4 bytes hold the selector.
+    let magic = &raw[..4];
+    if magic == EIP1271_MAGIC_VALUE {
+        Ok(())
+    } else {
+        Err(VoucherVerifyError::InvalidSignature)
+    }
+}
+
+/// Helper used by module-level tests to build a voucher signed by an EOA.
+///
+/// Not part of the production verify path — exposed to module tests and
+/// downstream integration tests so they can construct realistic vouchers
+/// without importing the full client crate.
+#[cfg(test)]
+#[allow(dead_code)] // used by downstream integration tests
+pub(crate) fn sign_voucher_for_test(
+    channel_id: B256,
+    max_claimable_amount: U128,
+    chain_id: u64,
+    signer: &alloy_signer_local::PrivateKeySigner,
+) -> alloy_primitives::Bytes {
+    use alloy_signer::SignerSync;
+    let digest = compute_voucher_digest(channel_id, max_claimable_amount, chain_id);
+    let signature = signer.sign_hash_sync(&digest).expect("eoa signing");
+    signature.as_bytes().to_vec().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chain::types::EOASignatureExt;
+    use crate::v2_eip155_batch_settlement::facilitator::utils::compute_channel_id;
+    use crate::v2_eip155_batch_settlement::types::ChannelConfig as WireChannelConfig;
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+
+    #[test]
+    fn ecdsa_voucher_recovers_to_signer() {
+        let signer = PrivateKeySigner::random();
+        let signer_address = signer.address();
+        let channel_id = B256::repeat_byte(0x42);
+        let max_claimable = U128::from(1_000u128);
+        let chain_id = 84532;
+
+        let digest = compute_voucher_digest(channel_id, max_claimable, chain_id);
+        let signature = signer.sign_hash_sync(&digest).unwrap();
+        let bytes = signature.as_bytes();
+        assert_eq!(bytes.len(), 65);
+
+        let result = recover_ecdsa_and_match(&bytes, &digest, signer_address);
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn ecdsa_voucher_rejects_signer_mismatch() {
+        let signer = PrivateKeySigner::random();
+        let other = PrivateKeySigner::random();
+        let channel_id = B256::repeat_byte(0x42);
+        let max_claimable = U128::from(1_000u128);
+        let chain_id = 84532;
+
+        let digest = compute_voucher_digest(channel_id, max_claimable, chain_id);
+        let signature = signer.sign_hash_sync(&digest).unwrap();
+        let bytes = signature.as_bytes();
+
+        let result = recover_ecdsa_and_match(&bytes, &digest, other.address());
+        assert_eq!(result, Err(VoucherVerifyError::InvalidSignature));
+    }
+
+    #[test]
+    fn ecdsa_voucher_rejects_garbage_signature() {
+        let channel_id = B256::repeat_byte(0x42);
+        let max_claimable = U128::from(1_000u128);
+        let chain_id = 84532;
+        let digest = compute_voucher_digest(channel_id, max_claimable, chain_id);
+
+        let result = recover_ecdsa_and_match(&[0u8; 32], &digest, Address::ZERO);
+        assert_eq!(result, Err(VoucherVerifyError::InvalidFormat));
+    }
+
+    #[test]
+    fn ecdsa_voucher_accepts_erc2098_compact_signature() {
+        let signer = PrivateKeySigner::random();
+        let signer_address = signer.address();
+        let channel_id = B256::repeat_byte(0x42);
+        let max_claimable = U128::from(1_000u128);
+        let chain_id = 84532;
+
+        let digest = compute_voucher_digest(channel_id, max_claimable, chain_id);
+        let signature = signer.sign_hash_sync(&digest).unwrap();
+        // ERC-2098 compact: drop the v byte from the 65-byte canonical form
+        // and encode y-parity in the high bit of `s`.
+        let mut compact = [0u8; 64];
+        compact[..32].copy_from_slice(signature.r_bytes().as_slice());
+        let s = signature.s_bytes();
+        compact[32..].copy_from_slice(s.as_slice());
+        if signature.v() {
+            compact[32] |= 0x80;
+        }
+        let result = recover_ecdsa_and_match(&compact, &digest, signer_address);
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn eip1271_magic_value_matches_canonical_selector() {
+        // 0x1626ba7e == bytes4(keccak256("isValidSignature(bytes32,bytes)"))
+        assert_eq!(EIP1271_MAGIC_VALUE, [0x16, 0x26, 0xba, 0x7e]);
+    }
+
+    /// End-to-end parity check: signing a voucher with the helper recovers to
+    /// the same EOA the verify path expects. This is the primary parity
+    /// assertion between the Rust port and the TS / Go reference signers.
+    #[test]
+    fn signed_voucher_round_trips_through_recover() {
+        let signer = PrivateKeySigner::random();
+        let signer_address = signer.address();
+        let cfg = WireChannelConfig {
+            payer: "0x0000000000000000000000000000000000000aaa"
+                .parse()
+                .unwrap(),
+            payer_authorizer: signer_address.into(),
+            receiver: "0x0000000000000000000000000000000000000bbb"
+                .parse()
+                .unwrap(),
+            receiver_authorizer: "0x0000000000000000000000000000000000000ccc"
+                .parse()
+                .unwrap(),
+            token: "0x0000000000000000000000000000000000000ddd"
+                .parse()
+                .unwrap(),
+            withdraw_delay: 900,
+            salt: B256::ZERO,
+        };
+        let chain_id = 84532u64;
+        let channel_id = compute_channel_id(&cfg, chain_id);
+        let max_claimable = U128::from(5_000u128);
+
+        let sig_bytes = sign_voucher_for_test(channel_id, max_claimable, chain_id, &signer);
+        let digest = compute_voucher_digest(channel_id, max_claimable, chain_id);
+        let result = recover_ecdsa_and_match(&sig_bytes, &digest, signer_address);
+        assert_eq!(result, Ok(()));
+    }
+}

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/mod.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/mod.rs
@@ -1,0 +1,66 @@
+//! V2 EIP-155 `batch-settlement` payment scheme implementation.
+//!
+//! `batch-settlement` is a capital-backed channel scheme for high-throughput,
+//! low-cost EVM payments. Clients deposit funds into onchain escrow once and
+//! sign off-chain **cumulative vouchers** per request; servers verify those
+//! vouchers with fast signature checks and claim them onchain periodically in
+//! batches. A single `claim` transaction can cover many channels at once and
+//! only updates onchain accounting — claimed funds are later transferred to
+//! the receiver via a separate `settle` operation that sweeps many claims into
+//! one token transfer.
+//!
+//! See `docs/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md`
+//! (mirrored from the upstream `x402-foundation/x402` repo) for the full spec.
+//!
+//! # Module Layout
+//!
+//! - [`constants`]   — canonical contract addresses + EIP-712 domain metadata
+//! - [`errors`]      — wire-format error code constants
+//! - [`encoding`]    — calldata-encoding helpers for deposit collectors
+//! - [`types`]       — wire types (payloads, channel config, vouchers, …)
+//! - [`facilitator`] — verify / settle / supported dispatcher (gated behind
+//!   the `facilitator` feature)
+//!
+//! # Scheme Identifier
+//!
+//! The blueprint registers itself as `v2-eip155-batch-settlement`.
+
+pub mod constants;
+pub mod encoding;
+pub mod errors;
+pub mod types;
+
+pub use types::{
+    AssetTransferMethod, BatchSettlementPayload, BatchSettlementPaymentRequirementsExtra,
+    BatchSettlementRefundPayload, BatchSettlementScheme, ChannelConfig, ChannelStateExtra,
+    ClaimPayload, DepositAuthorization, DepositPayload, DepositSegment, EnrichedRefundPayload,
+    Erc3009Authorization, PaymentPayload, PaymentRequirements, Permit2Authorization,
+    Permit2Permitted, Permit2Witness, RefundPayload, SettlePayload, SettleRequest, U128String,
+    U256String, VerifyRequest, VoucherClaim, VoucherClaimVoucher, VoucherFields, VoucherPayload,
+    VoucherStateExtra,
+};
+
+#[cfg(feature = "facilitator")]
+pub mod facilitator;
+#[cfg(feature = "facilitator")]
+pub use facilitator::{V2Eip155BatchSettlementConfig, V2Eip155BatchSettlementFacilitator};
+
+use x402_types::scheme::X402SchemeId;
+
+/// Scheme identifier blueprint for `v2-eip155-batch-settlement`.
+///
+/// This unit struct is the public entry point for registering the scheme with
+/// a [`x402_types::scheme::SchemeBlueprints`] registry. The facilitator-side
+/// implementation lives in [`facilitator`] (gated behind the `facilitator`
+/// feature).
+pub struct V2Eip155BatchSettlement;
+
+impl X402SchemeId for V2Eip155BatchSettlement {
+    fn namespace(&self) -> &str {
+        "eip155"
+    }
+
+    fn scheme(&self) -> &str {
+        BatchSettlementScheme.as_ref()
+    }
+}

--- a/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/types.rs
+++ b/crates/chains/x402-chain-eip155/src/v2_eip155_batch_settlement/types.rs
@@ -1,0 +1,814 @@
+//! Wire format types for the V2 EIP-155 `batch-settlement` payment scheme.
+//!
+//! Mirrors `typescript/packages/mechanisms/evm/src/batch-settlement/types.ts`.
+//! Every `serde`-derived type round-trips against the canonical JSON wire format
+//! used by the TypeScript and Go reference implementations.
+//!
+//! Numeric fields (`amount`, `maxClaimableAmount`, `nonce`, …) serialize as
+//! **decimal** strings via the `decimal_u128` / `decimal_u256` helpers — the
+//! default `alloy_primitives::Uint` `Serialize` impl emits `0x`-hex which is
+//! not compatible with the spec wire format.
+
+use alloy_primitives::{B256, Bytes, U128, U256};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+use std::fmt::{self, Formatter};
+use x402_types::lit_str;
+use x402_types::proto::v2;
+
+use crate::chain::ChecksummedAddress;
+
+lit_str!(BatchSettlementScheme, "batch-settlement");
+
+/// V2 `PaymentRequirements` for batch-settlement payments.
+pub type PaymentRequirements = v2::PaymentRequirements<
+    BatchSettlementScheme,
+    U256String,
+    ChecksummedAddress,
+    BatchSettlementPaymentRequirementsExtra,
+>;
+
+/// V2 `PaymentPayload` enveloping a batch-settlement payload of any variant.
+pub type PaymentPayload = v2::PaymentPayload<PaymentRequirements, BatchSettlementPayload>;
+
+/// V2 `VerifyRequest` for batch-settlement payments.
+pub type VerifyRequest = v2::VerifyRequest<PaymentPayload, PaymentRequirements>;
+
+/// V2 `SettleRequest` for batch-settlement payments (same shape as verify).
+pub type SettleRequest = VerifyRequest;
+
+/// Newtype around `U256` that serializes as a decimal string.
+///
+/// Used wherever the wire format requires a decimal-string amount field
+/// (per-request `PaymentRequirements.amount`, ERC-3009 `validAfter` / `validBefore`,
+/// Permit2 `nonce` / `deadline`, refund nonces, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct U256String(pub U256);
+
+impl From<U256> for U256String {
+    fn from(value: U256) -> Self {
+        Self(value)
+    }
+}
+
+impl From<U256String> for U256 {
+    fn from(value: U256String) -> Self {
+        value.0
+    }
+}
+
+impl Serialize for U256String {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for U256String {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        U256::from_str_radix(&s, 10)
+            .map(Self)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+impl fmt::Display for U256String {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Newtype around `U128` that serializes as a decimal string.
+///
+/// Used wherever the wire format requires a decimal-string `uint128` (channel
+/// balances, claim amounts, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct U128String(pub U128);
+
+impl From<U128> for U128String {
+    fn from(value: U128) -> Self {
+        Self(value)
+    }
+}
+
+impl From<U128String> for U128 {
+    fn from(value: U128String) -> Self {
+        value.0
+    }
+}
+
+impl Serialize for U128String {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for U128String {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        U128::from_str_radix(&s, 10)
+            .map(Self)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+impl fmt::Display for U128String {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Channel snapshot returned in `extra.channelState` on verify / settle responses
+/// and in corrective 402 `extra` blocks.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChannelStateExtra {
+    pub channel_id: B256,
+    pub balance: U128String,
+    pub total_claimed: U128String,
+    pub withdraw_requested_at: u64,
+    pub refund_nonce: U256String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub charged_cumulative_amount: Option<U128String>,
+}
+
+/// Corrective voucher snapshot included alongside `channelState` in a
+/// `invalid_batch_settlement_evm_cumulative_amount_mismatch` 402.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoucherStateExtra {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signed_max_claimable: Option<U128String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<Bytes>,
+}
+
+/// Asset transfer method selector hint included in `PaymentRequirements.extra`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AssetTransferMethod {
+    Eip3009,
+    Permit2,
+}
+
+impl fmt::Display for AssetTransferMethod {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            AssetTransferMethod::Eip3009 => f.write_str("eip3009"),
+            AssetTransferMethod::Permit2 => f.write_str("permit2"),
+        }
+    }
+}
+
+/// `PaymentRequirements.extra` for batch-settlement payments.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchSettlementPaymentRequirementsExtra {
+    pub receiver_authorizer: ChecksummedAddress,
+    pub withdraw_delay: u64,
+    pub name: String,
+    pub version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asset_transfer_method: Option<AssetTransferMethod>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel_state: Option<ChannelStateExtra>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub voucher_state: Option<VoucherStateExtra>,
+}
+
+/// Immutable channel configuration; its EIP-712 hash under the
+/// `x402 Batch Settlement` domain is the canonical `channelId`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChannelConfig {
+    pub payer: ChecksummedAddress,
+    pub payer_authorizer: ChecksummedAddress,
+    pub receiver: ChecksummedAddress,
+    pub receiver_authorizer: ChecksummedAddress,
+    pub token: ChecksummedAddress,
+    pub withdraw_delay: u64,
+    pub salt: B256,
+}
+
+/// Per-voucher fields shared by deposit, voucher, and refund payloads.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoucherFields {
+    pub channel_id: B256,
+    pub max_claimable_amount: U128String,
+    pub signature: Bytes,
+}
+
+/// ERC-3009 `ReceiveWithAuthorization` segment used inside a deposit payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Erc3009Authorization {
+    pub valid_after: U256String,
+    pub valid_before: U256String,
+    pub salt: B256,
+    pub signature: Bytes,
+}
+
+/// Permit2 authorization segment used inside a deposit payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Permit2Authorization {
+    pub from: ChecksummedAddress,
+    pub permitted: Permit2Permitted,
+    pub spender: ChecksummedAddress,
+    pub nonce: U256String,
+    pub deadline: U256String,
+    pub witness: Permit2Witness,
+    pub signature: Bytes,
+}
+
+/// Token permission segment of a Permit2 authorization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Permit2Permitted {
+    pub token: ChecksummedAddress,
+    pub amount: U256String,
+}
+
+/// Permit2 deposit witness: binds the authorization to a single channel.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Permit2Witness {
+    pub channel_id: B256,
+}
+
+/// Exactly-one wrapper around the two supported deposit authorization variants.
+///
+/// The wire shape is an object with exactly one of `erc3009Authorization` or
+/// `permit2Authorization`; the other key MUST be absent (mirrors the TS
+/// discriminated union — see `BatchSettlementDepositAuthorization`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DepositAuthorization {
+    Erc3009(Erc3009Authorization),
+    Permit2(Permit2Authorization),
+}
+
+impl Serialize for DepositAuthorization {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Wire<'a> {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            erc3009_authorization: Option<&'a Erc3009Authorization>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            permit2_authorization: Option<&'a Permit2Authorization>,
+        }
+        let wire = match self {
+            DepositAuthorization::Erc3009(a) => Wire {
+                erc3009_authorization: Some(a),
+                permit2_authorization: None,
+            },
+            DepositAuthorization::Permit2(a) => Wire {
+                erc3009_authorization: None,
+                permit2_authorization: Some(a),
+            },
+        };
+        wire.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DepositAuthorization {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Wire {
+            #[serde(default)]
+            erc3009_authorization: Option<Erc3009Authorization>,
+            #[serde(default)]
+            permit2_authorization: Option<Permit2Authorization>,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        match (wire.erc3009_authorization, wire.permit2_authorization) {
+            (Some(a), None) => Ok(DepositAuthorization::Erc3009(a)),
+            (None, Some(a)) => Ok(DepositAuthorization::Permit2(a)),
+            (Some(_), Some(_)) => Err(D::Error::custom(
+                "deposit.authorization must include exactly one of \
+                 erc3009Authorization or permit2Authorization",
+            )),
+            (None, None) => Err(D::Error::custom(
+                "deposit.authorization must include either erc3009Authorization \
+                 or permit2Authorization",
+            )),
+        }
+    }
+}
+
+/// Deposit segment: the amount transferred into the channel and how it is collected.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DepositSegment {
+    pub amount: U256String,
+    pub authorization: DepositAuthorization,
+}
+
+/// `type: "deposit"` payload: first request (or top-up) creates / extends the
+/// channel via the canonical deposit collector and authorizes the accompanying
+/// voucher.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DepositPayload {
+    pub channel_config: ChannelConfig,
+    pub voucher: VoucherFields,
+    pub deposit: DepositSegment,
+}
+
+/// `type: "voucher"` payload: steady-state cumulative voucher against an
+/// existing channel.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoucherPayload {
+    pub channel_config: ChannelConfig,
+    pub voucher: VoucherFields,
+}
+
+/// `type: "refund"` payload (client form): cooperative refund request authored
+/// by the client. The optional `amount` requests a partial refund; if omitted,
+/// the server resolves it to a full refund before forwarding the enriched
+/// payload to the facilitator.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefundPayload {
+    pub channel_config: ChannelConfig,
+    pub voucher: VoucherFields,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub amount: Option<U256String>,
+}
+
+/// A claim row consumed by `claimWithSignature` / `claim` onchain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoucherClaim {
+    pub voucher: VoucherClaimVoucher,
+    pub signature: Bytes,
+    pub total_claimed: U128String,
+}
+
+/// Voucher segment of a claim row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoucherClaimVoucher {
+    pub channel: ChannelConfig,
+    pub max_claimable_amount: U128String,
+}
+
+/// `type: "claim"` settle payload authored by the server.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimPayload {
+    pub claims: Vec<VoucherClaim>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim_authorizer_signature: Option<Bytes>,
+}
+
+/// `type: "settle"` settle payload authored by the server.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettlePayload {
+    pub receiver: ChecksummedAddress,
+    pub token: ChecksummedAddress,
+}
+
+/// `type: "refund"` settle payload after the server enriches the client's
+/// refund payload with the resolved amount, nonce, claim batch, and any
+/// receiver-authorizer signatures it owns.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnrichedRefundPayload {
+    pub channel_config: ChannelConfig,
+    pub voucher: VoucherFields,
+    pub amount: U256String,
+    pub refund_nonce: U256String,
+    #[serde(default)]
+    pub claims: Vec<VoucherClaim>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refund_authorizer_signature: Option<Bytes>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim_authorizer_signature: Option<Bytes>,
+}
+
+/// Refund payload variant: either the bare client-side request or the
+/// enriched server-side settlement payload. Distinguished by the presence of
+/// `refundNonce`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BatchSettlementRefundPayload {
+    Client(RefundPayload),
+    Enriched(EnrichedRefundPayload),
+}
+
+impl Serialize for BatchSettlementRefundPayload {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            BatchSettlementRefundPayload::Client(p) => p.serialize(serializer),
+            BatchSettlementRefundPayload::Enriched(p) => p.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for BatchSettlementRefundPayload {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Materialize the JSON value once so we can dispatch on the presence
+        // of the enriched fields. The enriched form always carries
+        // `refundNonce`; the bare client form never does.
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let has_refund_nonce = value
+            .as_object()
+            .map(|obj| obj.contains_key("refundNonce"))
+            .unwrap_or(false);
+        if has_refund_nonce {
+            serde_json::from_value::<EnrichedRefundPayload>(value)
+                .map(BatchSettlementRefundPayload::Enriched)
+                .map_err(D::Error::custom)
+        } else {
+            serde_json::from_value::<RefundPayload>(value)
+                .map(BatchSettlementRefundPayload::Client)
+                .map_err(D::Error::custom)
+        }
+    }
+}
+
+impl BatchSettlementRefundPayload {
+    /// Returns the channel config shared by both refund variants.
+    pub fn channel_config(&self) -> &ChannelConfig {
+        match self {
+            BatchSettlementRefundPayload::Client(p) => &p.channel_config,
+            BatchSettlementRefundPayload::Enriched(p) => &p.channel_config,
+        }
+    }
+
+    /// Returns the voucher fields shared by both refund variants.
+    pub fn voucher(&self) -> &VoucherFields {
+        match self {
+            BatchSettlementRefundPayload::Client(p) => &p.voucher,
+            BatchSettlementRefundPayload::Enriched(p) => &p.voucher,
+        }
+    }
+}
+
+/// Discriminated union of every payload variant the facilitator can receive.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum BatchSettlementPayload {
+    Deposit(DepositPayload),
+    Voucher(VoucherPayload),
+    Refund(BatchSettlementRefundPayload),
+    Claim(ClaimPayload),
+    Settle(SettlePayload),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Address, b256};
+    use serde_json::json;
+
+    fn sample_channel_config() -> ChannelConfig {
+        ChannelConfig {
+            payer: "0x0000000000000000000000000000000000000001"
+                .parse()
+                .unwrap(),
+            payer_authorizer: "0x0000000000000000000000000000000000000002"
+                .parse()
+                .unwrap(),
+            receiver: "0x0000000000000000000000000000000000000003"
+                .parse()
+                .unwrap(),
+            receiver_authorizer: "0x0000000000000000000000000000000000000004"
+                .parse()
+                .unwrap(),
+            token: "0x0000000000000000000000000000000000000005"
+                .parse()
+                .unwrap(),
+            withdraw_delay: 900,
+            salt: B256::ZERO,
+        }
+    }
+
+    fn sample_voucher() -> VoucherFields {
+        VoucherFields {
+            channel_id: b256!("0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc1230000"),
+            max_claimable_amount: U128::from(1_000u128).into(),
+            signature: Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+        }
+    }
+
+    #[test]
+    fn u256_string_serializes_as_decimal() {
+        let v = U256String(U256::from(100_000u64));
+        let json = serde_json::to_value(v).unwrap();
+        assert_eq!(json, json!("100000"));
+        let back: U256String = serde_json::from_value(json).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn u128_string_serializes_as_decimal() {
+        let v = U128String(U128::from(42u128));
+        let json = serde_json::to_value(v).unwrap();
+        assert_eq!(json, json!("42"));
+        let back: U128String = serde_json::from_value(json).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn u128_string_rejects_hex_input() {
+        // The decimal parser must reject a `0x`-prefixed input — anything
+        // outside [0-9] is an out-of-range digit. Compatibility with
+        // hex-style strings would silently truncate the payload's amount.
+        let err = serde_json::from_value::<U128String>(json!("0x64")).unwrap_err();
+        let s = err.to_string();
+        assert!(
+            s.contains("out of range") || s.contains("invalid"),
+            "expected decimal parse rejection, got: {s}"
+        );
+    }
+
+    #[test]
+    fn deposit_payload_round_trips_with_erc3009() {
+        let payload = BatchSettlementPayload::Deposit(DepositPayload {
+            channel_config: sample_channel_config(),
+            voucher: sample_voucher(),
+            deposit: DepositSegment {
+                amount: U256::from(1_000u64).into(),
+                authorization: DepositAuthorization::Erc3009(Erc3009Authorization {
+                    valid_after: U256::ZERO.into(),
+                    valid_before: U256::from(1_770_000_000u64).into(),
+                    salt: B256::repeat_byte(0x11),
+                    signature: Bytes::from_static(&[0x01, 0x02]),
+                }),
+            },
+        });
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["type"], "deposit");
+        assert_eq!(json["deposit"]["amount"], "1000");
+        assert_eq!(
+            json["deposit"]["authorization"]["erc3009Authorization"]["validBefore"],
+            "1770000000"
+        );
+        assert!(json["deposit"]["authorization"]["permit2Authorization"].is_null());
+        let back: BatchSettlementPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(back, payload);
+    }
+
+    #[test]
+    fn deposit_payload_round_trips_with_permit2() {
+        let payload = BatchSettlementPayload::Deposit(DepositPayload {
+            channel_config: sample_channel_config(),
+            voucher: sample_voucher(),
+            deposit: DepositSegment {
+                amount: U256::from(2_000u64).into(),
+                authorization: DepositAuthorization::Permit2(Permit2Authorization {
+                    from: "0x0000000000000000000000000000000000000001"
+                        .parse()
+                        .unwrap(),
+                    permitted: Permit2Permitted {
+                        token: "0x0000000000000000000000000000000000000005"
+                            .parse()
+                            .unwrap(),
+                        amount: U256::from(2_000u64).into(),
+                    },
+                    spender: "0x4020425fAf3b746C082C2f942b4E5159887b0005"
+                        .parse()
+                        .unwrap(),
+                    nonce: U256::from(42u64).into(),
+                    deadline: U256::from(1_770_000_000u64).into(),
+                    witness: Permit2Witness {
+                        channel_id: sample_voucher().channel_id,
+                    },
+                    signature: Bytes::from_static(&[0x03, 0x04]),
+                }),
+            },
+        });
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["type"], "deposit");
+        assert_eq!(
+            json["deposit"]["authorization"]["permit2Authorization"]["nonce"],
+            "42"
+        );
+        assert!(json["deposit"]["authorization"]["erc3009Authorization"].is_null());
+        let back: BatchSettlementPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(back, payload);
+    }
+
+    #[test]
+    fn deposit_authorization_rejects_both_variants_present() {
+        let json = json!({
+            "erc3009Authorization": {
+                "validAfter": "0",
+                "validBefore": "1",
+                "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "signature": "0x"
+            },
+            "permit2Authorization": {
+                "from": "0x0000000000000000000000000000000000000001",
+                "permitted": { "token": "0x0000000000000000000000000000000000000005", "amount": "1" },
+                "spender": "0x4020425fAf3b746C082C2f942b4E5159887b0005",
+                "nonce": "0",
+                "deadline": "0",
+                "witness": { "channelId": "0x0000000000000000000000000000000000000000000000000000000000000000" },
+                "signature": "0x"
+            }
+        });
+        let err = serde_json::from_value::<DepositAuthorization>(json).unwrap_err();
+        assert!(err.to_string().contains("exactly one"), "{err}");
+    }
+
+    #[test]
+    fn deposit_authorization_rejects_neither_variant_present() {
+        let err = serde_json::from_value::<DepositAuthorization>(json!({})).unwrap_err();
+        assert!(err.to_string().contains("must include"));
+    }
+
+    #[test]
+    fn voucher_payload_round_trips() {
+        let payload = BatchSettlementPayload::Voucher(VoucherPayload {
+            channel_config: sample_channel_config(),
+            voucher: sample_voucher(),
+        });
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["type"], "voucher");
+        assert_eq!(json["voucher"]["maxClaimableAmount"], "1000");
+        let back: BatchSettlementPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(back, payload);
+    }
+
+    #[test]
+    fn refund_payload_client_round_trips() {
+        let payload =
+            BatchSettlementPayload::Refund(BatchSettlementRefundPayload::Client(RefundPayload {
+                channel_config: sample_channel_config(),
+                voucher: sample_voucher(),
+                amount: Some(U256::from(500u64).into()),
+            }));
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["type"], "refund");
+        assert_eq!(json["amount"], "500");
+        assert!(json["refundNonce"].is_null());
+        let back: BatchSettlementPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(back, payload);
+    }
+
+    #[test]
+    fn refund_payload_enriched_round_trips() {
+        let payload = BatchSettlementPayload::Refund(BatchSettlementRefundPayload::Enriched(
+            EnrichedRefundPayload {
+                channel_config: sample_channel_config(),
+                voucher: sample_voucher(),
+                amount: U256::from(500u64).into(),
+                refund_nonce: U256::from(1u64).into(),
+                claims: vec![VoucherClaim {
+                    voucher: VoucherClaimVoucher {
+                        channel: sample_channel_config(),
+                        max_claimable_amount: U128::from(700u128).into(),
+                    },
+                    signature: Bytes::from_static(&[0xaa, 0xbb]),
+                    total_claimed: U128::from(700u128).into(),
+                }],
+                refund_authorizer_signature: Some(Bytes::from_static(&[0xcc, 0xdd])),
+                claim_authorizer_signature: None,
+            },
+        ));
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["type"], "refund");
+        assert_eq!(json["refundNonce"], "1");
+        assert_eq!(json["claims"][0]["totalClaimed"], "700");
+        let back: BatchSettlementPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(back, payload);
+    }
+
+    #[test]
+    fn claim_payload_round_trips() {
+        let payload = BatchSettlementPayload::Claim(ClaimPayload {
+            claims: vec![VoucherClaim {
+                voucher: VoucherClaimVoucher {
+                    channel: sample_channel_config(),
+                    max_claimable_amount: U128::from(5_000u128).into(),
+                },
+                signature: Bytes::from_static(&[0x11]),
+                total_claimed: U128::from(5_000u128).into(),
+            }],
+            claim_authorizer_signature: Some(Bytes::from_static(&[0x22])),
+        });
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["type"], "claim");
+        let back: BatchSettlementPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(back, payload);
+    }
+
+    #[test]
+    fn settle_payload_round_trips() {
+        let payload = BatchSettlementPayload::Settle(SettlePayload {
+            receiver: "0x0000000000000000000000000000000000000003"
+                .parse()
+                .unwrap(),
+            token: "0x0000000000000000000000000000000000000005"
+                .parse()
+                .unwrap(),
+        });
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["type"], "settle");
+        let back: BatchSettlementPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(back, payload);
+    }
+
+    #[test]
+    fn payment_requirements_extra_round_trips() {
+        let extra = BatchSettlementPaymentRequirementsExtra {
+            receiver_authorizer: "0x0000000000000000000000000000000000000004"
+                .parse()
+                .unwrap(),
+            withdraw_delay: 900,
+            name: "USDC".to_string(),
+            version: "2".to_string(),
+            asset_transfer_method: Some(AssetTransferMethod::Eip3009),
+            channel_state: Some(ChannelStateExtra {
+                channel_id: B256::repeat_byte(0x55),
+                balance: U128::from(100_000u128).into(),
+                total_claimed: U128::from(3_200u128).into(),
+                withdraw_requested_at: 0,
+                refund_nonce: U256::from(1u64).into(),
+                charged_cumulative_amount: Some(U128::from(3_900u128).into()),
+            }),
+            voucher_state: Some(VoucherStateExtra {
+                signed_max_claimable: Some(U128::from(3_900u128).into()),
+                signature: Some(Bytes::from_static(&[0xab, 0xcd])),
+            }),
+        };
+        let json = serde_json::to_value(&extra).unwrap();
+        assert_eq!(
+            json["receiverAuthorizer"],
+            "0x0000000000000000000000000000000000000004"
+        );
+        assert_eq!(json["assetTransferMethod"], "eip3009");
+        assert_eq!(json["channelState"]["chargedCumulativeAmount"], "3900");
+        assert_eq!(json["channelState"]["balance"], "100000");
+        let back: BatchSettlementPaymentRequirementsExtra = serde_json::from_value(json).unwrap();
+        assert_eq!(back, extra);
+    }
+
+    #[test]
+    fn unknown_payload_type_is_rejected() {
+        let json = json!({ "type": "withdraw" });
+        let err = serde_json::from_value::<BatchSettlementPayload>(json).unwrap_err();
+        assert!(err.to_string().contains("withdraw"), "{err}");
+    }
+
+    #[test]
+    fn batch_settlement_scheme_literal_round_trips() {
+        let scheme: BatchSettlementScheme = "batch-settlement".parse().unwrap();
+        assert_eq!(scheme.to_string(), "batch-settlement");
+        let json = serde_json::to_value(scheme).unwrap();
+        assert_eq!(json, json!("batch-settlement"));
+        let back: BatchSettlementScheme = serde_json::from_value(json).unwrap();
+        assert_eq!(back, scheme);
+        assert!("exact".parse::<BatchSettlementScheme>().is_err());
+    }
+
+    /// Address fields on `ChannelConfig` must serialize as EIP-55 checksummed
+    /// hex so the chain-bound EIP-712 hash matches the reference implementations.
+    #[test]
+    fn channel_config_serializes_checksummed_addresses() {
+        let cfg = ChannelConfig {
+            payer: Address::from_word(B256::repeat_byte(0xab)).into(),
+            payer_authorizer: Address::from_word(B256::repeat_byte(0xcd)).into(),
+            receiver: Address::from_word(B256::repeat_byte(0xef)).into(),
+            receiver_authorizer: Address::from_word(B256::repeat_byte(0x12)).into(),
+            token: Address::from_word(B256::repeat_byte(0x34)).into(),
+            withdraw_delay: 900,
+            salt: B256::ZERO,
+        };
+        let json = serde_json::to_value(&cfg).unwrap();
+        let payer = json["payer"].as_str().unwrap();
+        assert!(
+            payer.chars().any(|c| c.is_ascii_uppercase()),
+            "payer should be checksummed: {payer}"
+        );
+    }
+}

--- a/crates/chains/x402-chain-eip155/tests/batch_settlement_parity.rs
+++ b/crates/chains/x402-chain-eip155/tests/batch_settlement_parity.rs
@@ -1,0 +1,252 @@
+//! Cross-module integration tests for the V2 EIP-155 `batch-settlement` scheme.
+//!
+//! These tests sit at the crate boundary so they exercise the publicly
+//! re-exported API the same way downstream consumers (the facilitator binary,
+//! examples, protocol-compliance harness) do.
+
+#![cfg(feature = "facilitator")]
+
+use alloy_primitives::{B256, U128, U256, b256};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use serde_json::json;
+use x402_chain_eip155::v2_eip155_batch_settlement::{
+    BatchSettlementPayload, BatchSettlementPaymentRequirementsExtra, BatchSettlementScheme,
+    ChannelConfig, DepositAuthorization, DepositPayload, DepositSegment, Erc3009Authorization,
+    PaymentRequirements, RefundPayload, U256String, VoucherFields, VoucherPayload,
+    facilitator::{
+        BatchSettlementVerifyResponse, ReceiverAuthorizerSigner, compute_channel_id,
+        compute_voucher_digest,
+    },
+    types::BatchSettlementRefundPayload,
+};
+
+const BASE_SEPOLIA_CHAIN_ID: u64 = 84_532;
+
+fn sample_extra(authorizer: &str) -> BatchSettlementPaymentRequirementsExtra {
+    BatchSettlementPaymentRequirementsExtra {
+        receiver_authorizer: authorizer.parse().unwrap(),
+        withdraw_delay: 900,
+        name: "USDC".into(),
+        version: "2".into(),
+        asset_transfer_method: None,
+        channel_state: None,
+        voucher_state: None,
+    }
+}
+
+fn sample_requirements(receiver: &str, authorizer: &str, token: &str) -> PaymentRequirements {
+    PaymentRequirements {
+        scheme: BatchSettlementScheme,
+        network: x402_types::chain::ChainId::new("eip155", "84532"),
+        amount: U256String::from(U256::from(1_000u64)),
+        pay_to: receiver.parse().unwrap(),
+        max_timeout_seconds: 300,
+        asset: token.parse().unwrap(),
+        extra: sample_extra(authorizer),
+    }
+}
+
+fn sample_config(payer_authorizer: &str) -> ChannelConfig {
+    ChannelConfig {
+        payer: "0x0000000000000000000000000000000000000001"
+            .parse()
+            .unwrap(),
+        payer_authorizer: payer_authorizer.parse().unwrap(),
+        receiver: "0x0000000000000000000000000000000000000003"
+            .parse()
+            .unwrap(),
+        receiver_authorizer: "0x0000000000000000000000000000000000000004"
+            .parse()
+            .unwrap(),
+        token: "0x0000000000000000000000000000000000000005"
+            .parse()
+            .unwrap(),
+        withdraw_delay: 900,
+        salt: B256::ZERO,
+    }
+}
+
+#[test]
+fn payment_payload_voucher_round_trips_via_value() {
+    let cfg = sample_config("0x0000000000000000000000000000000000000002");
+    let voucher_fields = VoucherFields {
+        channel_id: b256!("0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc1230000"),
+        max_claimable_amount: U128::from(2_000u128).into(),
+        signature: alloy_primitives::Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+    };
+    let payload = BatchSettlementPayload::Voucher(VoucherPayload {
+        channel_config: cfg,
+        voucher: voucher_fields,
+    });
+    let json = serde_json::to_value(&payload).unwrap();
+    assert_eq!(json["type"], "voucher");
+    assert_eq!(json["voucher"]["maxClaimableAmount"], "2000");
+    let back: BatchSettlementPayload = serde_json::from_value(json).unwrap();
+    assert_eq!(back, payload);
+}
+
+#[test]
+fn payment_payload_deposit_round_trips_via_value() {
+    let cfg = sample_config("0x0000000000000000000000000000000000000002");
+    let voucher_fields = VoucherFields {
+        channel_id: B256::repeat_byte(0x42),
+        max_claimable_amount: U128::from(1_000u128).into(),
+        signature: alloy_primitives::Bytes::from_static(&[0x01, 0x02]),
+    };
+    let payload = BatchSettlementPayload::Deposit(DepositPayload {
+        channel_config: cfg,
+        voucher: voucher_fields,
+        deposit: DepositSegment {
+            amount: U256::from(100_000u64).into(),
+            authorization: DepositAuthorization::Erc3009(Erc3009Authorization {
+                valid_after: U256::ZERO.into(),
+                valid_before: U256::from(1_770_000_000u64).into(),
+                salt: B256::repeat_byte(0x11),
+                signature: alloy_primitives::Bytes::from_static(&[0x03, 0x04]),
+            }),
+        },
+    });
+    let json = serde_json::to_value(&payload).unwrap();
+    assert_eq!(json["type"], "deposit");
+    assert_eq!(json["deposit"]["amount"], "100000");
+    let back: BatchSettlementPayload = serde_json::from_value(json).unwrap();
+    assert_eq!(back, payload);
+}
+
+#[test]
+fn refund_payload_distinguishes_client_vs_enriched() {
+    let cfg = sample_config("0x0000000000000000000000000000000000000002");
+    let voucher_fields = VoucherFields {
+        channel_id: B256::repeat_byte(0x77),
+        max_claimable_amount: U128::from(3_200u128).into(),
+        signature: alloy_primitives::Bytes::new(),
+    };
+
+    let client =
+        BatchSettlementPayload::Refund(BatchSettlementRefundPayload::Client(RefundPayload {
+            channel_config: cfg.clone(),
+            voucher: voucher_fields.clone(),
+            amount: Some(U256::from(500u64).into()),
+        }));
+    let client_json = serde_json::to_value(&client).unwrap();
+    assert!(client_json["refundNonce"].is_null());
+    let back: BatchSettlementPayload = serde_json::from_value(client_json).unwrap();
+    assert_eq!(back, client);
+
+    // Now an enriched form gains `refundNonce` and `claims` and dispatches
+    // to the `Enriched` variant on deserialization.
+    let enriched_json = json!({
+        "type": "refund",
+        "channelConfig": serde_json::to_value(&cfg).unwrap(),
+        "voucher": serde_json::to_value(&voucher_fields).unwrap(),
+        "amount": "500",
+        "refundNonce": "1",
+        "claims": [],
+    });
+    let back_enriched: BatchSettlementPayload = serde_json::from_value(enriched_json).unwrap();
+    let BatchSettlementPayload::Refund(BatchSettlementRefundPayload::Enriched(enriched)) =
+        back_enriched
+    else {
+        panic!("expected enriched refund payload");
+    };
+    assert_eq!(enriched.refund_nonce.0, U256::from(1u64));
+    assert_eq!(enriched.amount.0, U256::from(500u64));
+    assert!(enriched.refund_authorizer_signature.is_none());
+}
+
+#[test]
+fn channel_id_matches_independently_computed_eip712_hash() {
+    // Two channels with everything identical except `salt` MUST yield distinct
+    // channel ids, and two identical configs on different chains MUST also
+    // differ — that's the security property the chain-bound EIP-712 domain
+    // gives us.
+    let cfg_a = sample_config("0x0000000000000000000000000000000000000002");
+    let cfg_b = {
+        let mut c = cfg_a.clone();
+        c.salt = B256::repeat_byte(0x99);
+        c
+    };
+    assert_ne!(
+        compute_channel_id(&cfg_a, BASE_SEPOLIA_CHAIN_ID),
+        compute_channel_id(&cfg_b, BASE_SEPOLIA_CHAIN_ID),
+    );
+    assert_ne!(
+        compute_channel_id(&cfg_a, BASE_SEPOLIA_CHAIN_ID),
+        compute_channel_id(&cfg_a, 1),
+    );
+}
+
+#[test]
+fn payment_requirements_extra_serializes_channel_state_when_present() {
+    let req = sample_requirements(
+        "0x0000000000000000000000000000000000000003",
+        "0x0000000000000000000000000000000000000004",
+        "0x0000000000000000000000000000000000000005",
+    );
+    let json = serde_json::to_value(&req).unwrap();
+    assert_eq!(json["scheme"], "batch-settlement");
+    assert_eq!(json["network"], "eip155:84532");
+    assert_eq!(json["amount"], "1000");
+    assert_eq!(
+        json["extra"]["receiverAuthorizer"],
+        "0x0000000000000000000000000000000000000004"
+    );
+    let back: PaymentRequirements = serde_json::from_value(json).unwrap();
+    assert_eq!(back.network, req.network);
+    assert_eq!(back.amount.0, req.amount.0);
+}
+
+#[test]
+fn verify_response_invalid_round_trips_with_payer_and_reason() {
+    let resp = BatchSettlementVerifyResponse::invalid(
+        Some("0xPayer".into()),
+        "invalid_batch_settlement_evm_voucher_signature",
+    );
+    let json = serde_json::to_value(&resp).unwrap();
+    assert_eq!(json["isValid"], false);
+    assert_eq!(json["payer"], "0xPayer");
+    assert_eq!(
+        json["invalidReason"],
+        "invalid_batch_settlement_evm_voucher_signature"
+    );
+}
+
+#[test]
+fn receiver_authorizer_signs_and_recovers_for_voucher_digest() {
+    let signer = PrivateKeySigner::random();
+    let authorizer_address = signer.address();
+    let authorizer = ReceiverAuthorizerSigner::new(signer);
+
+    // Compute a voucher digest, sign it as if we were the payer authorizer,
+    // and confirm the recovered address matches.
+    let cfg = sample_config(&format!("{:#x}", authorizer_address));
+    let channel_id = compute_channel_id(&cfg, BASE_SEPOLIA_CHAIN_ID);
+    let max_claimable = U128::from(1_500u128);
+    let voucher_digest = compute_voucher_digest(channel_id, max_claimable, BASE_SEPOLIA_CHAIN_ID);
+
+    let raw_sig: alloy_primitives::Bytes =
+        // sign as the same EOA — this is the same flow the client would use.
+        authorizer
+            .sign_refund(channel_id, max_claimable, U256::ZERO, BASE_SEPOLIA_CHAIN_ID)
+            .unwrap();
+
+    // The refund and voucher digests differ, so the *recovered* refund
+    // signer must NOT match the voucher digest's signer.
+    let sig = alloy_primitives::Signature::from_raw(&raw_sig)
+        .unwrap()
+        .normalized_s();
+    let from_refund = sig.recover_address_from_prehash(&voucher_digest);
+    assert!(from_refund.is_err() || from_refund.unwrap() != authorizer_address);
+
+    // The dedicated EOA flow used by clients: hash the voucher digest with
+    // the signer and confirm recovery against the EOA.
+    let voucher_signer = PrivateKeySigner::random();
+    let voucher_signer_address = voucher_signer.address();
+    let voucher_sig = voucher_signer.sign_hash_sync(&voucher_digest).unwrap();
+    let recovered = voucher_sig
+        .normalized_s()
+        .recover_address_from_prehash(&voucher_digest)
+        .unwrap();
+    assert_eq!(recovered, voucher_signer_address);
+}

--- a/crates/chains/x402-chain-eip155/tests/batch_settlement_parity.rs
+++ b/crates/chains/x402-chain-eip155/tests/batch_settlement_parity.rs
@@ -6,20 +6,54 @@
 
 #![cfg(feature = "facilitator")]
 
-use alloy_primitives::{B256, U128, U256, b256};
+use alloy_primitives::{Address, B256, Signature, U128, U256, b256, hex};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use serde_json::json;
 use x402_chain_eip155::v2_eip155_batch_settlement::{
     BatchSettlementPayload, BatchSettlementPaymentRequirementsExtra, BatchSettlementScheme,
-    ChannelConfig, DepositAuthorization, DepositPayload, DepositSegment, Erc3009Authorization,
-    PaymentRequirements, RefundPayload, U256String, VoucherFields, VoucherPayload,
+    ChannelConfig, ClaimPayload, DepositAuthorization, DepositPayload, DepositSegment,
+    Erc3009Authorization, PaymentRequirements, RefundPayload, SettlePayload, U256String,
+    VoucherClaim, VoucherClaimVoucher, VoucherFields, VoucherPayload,
     facilitator::{
         BatchSettlementVerifyResponse, ReceiverAuthorizerSigner, compute_channel_id,
         compute_voucher_digest,
     },
     types::BatchSettlementRefundPayload,
 };
+
+// --- Cross-implementation viem reference vector ----------------------------
+// A fully concrete payer / channel / voucher tuple whose hashes and signature
+// were produced with viem (the TypeScript library the x402 client SDK signs
+// with) and independently reproduced by a hand-rolled keccak256 + abi.encode
+// implementation. Pinning these here makes `alloy_sol_types`' typed-data
+// derivation and `alloy_primitives`' ECDSA recovery agree with a real
+// client-produced signature byte-for-byte. Source:
+// https://github.com/Adelagric/x402-batch-settlement (crates/x402/tests).
+const VIEM_PAYER: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+const VIEM_RECEIVER: &str = "0x19ee5100D3a1e687F85B952bd3FbEc108Ab6A8d7";
+const VIEM_RECEIVER_AUTHORIZER: &str = "0xd407e409E34E0b9afb99EcCeb609bDbcD5e7f1bf";
+const VIEM_TOKEN: &str = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+const VIEM_CHANNEL_ID: B256 =
+    b256!("0x5fafb915f0dbee350d7f84d91802dea47e8e3a71929c3cd79da161c291fb28bd");
+const VIEM_VOUCHER_DIGEST: B256 =
+    b256!("0xa2874adbecca0abb1884b4ac1c100e3906d25208ad0c9e6a8fcf9790ccfa2246");
+// 65-byte secp256k1 signature produced by viem over VIEM_VOUCHER_DIGEST,
+// signed by VIEM_PAYER (acting as its own payerAuthorizer).
+const VIEM_SIGNATURE: &str = "0x6ad7a9c0cd0172b09704c56dd22de6d2877cf912de007dcdc7757a68756b84af2d2767327e6b84836fe2b48fd1b09675957c2fa4ec6c33a146dddd0e823cf1341c";
+const VIEM_MAX_CLAIMABLE: u128 = 1_000;
+
+fn viem_channel_config() -> ChannelConfig {
+    ChannelConfig {
+        payer: VIEM_PAYER.parse().unwrap(),
+        payer_authorizer: VIEM_PAYER.parse().unwrap(),
+        receiver: VIEM_RECEIVER.parse().unwrap(),
+        receiver_authorizer: VIEM_RECEIVER_AUTHORIZER.parse().unwrap(),
+        token: VIEM_TOKEN.parse().unwrap(),
+        withdraw_delay: 900,
+        salt: B256::ZERO,
+    }
+}
 
 const BASE_SEPOLIA_CHAIN_ID: u64 = 84_532;
 
@@ -178,6 +212,191 @@ fn channel_id_matches_independently_computed_eip712_hash() {
 }
 
 #[test]
+fn channel_id_with_nonzero_salt_matches_viem_reference_vector() {
+    // Same `ChannelConfig` as `channel_id_matches_viem_reference_vector`
+    // except `salt` is now `0x4242…4242`. Pins that `salt` actually
+    // participates in the EIP-712 hash — a wrong salt encoding would
+    // produce a different channel id from viem.
+    let cfg = ChannelConfig {
+        payer: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+            .parse()
+            .unwrap(),
+        payer_authorizer: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+            .parse()
+            .unwrap(),
+        receiver: "0x19ee5100D3a1e687F85B952bd3FbEc108Ab6A8d7"
+            .parse()
+            .unwrap(),
+        receiver_authorizer: "0xd407e409E34E0b9afb99EcCeb609bDbcD5e7f1bf"
+            .parse()
+            .unwrap(),
+        token: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+            .parse()
+            .unwrap(),
+        withdraw_delay: 900,
+        salt: B256::repeat_byte(0x42),
+    };
+    assert_eq!(
+        compute_channel_id(&cfg, BASE_SEPOLIA_CHAIN_ID),
+        b256!("0x7b3bf678a448e1882ab277b789987b5dee3b7cc6fc2c7e91687a74b54b474423"),
+    );
+}
+
+#[test]
+fn channel_id_chain_id_1_matches_viem_reference_vector() {
+    // Same config as `channel_id_matches_viem_reference_vector` but
+    // computed on chain id 1 (Ethereum mainnet). The chain-bound
+    // EIP-712 domain must produce a different channel id than the
+    // Base Sepolia one — pins that `chainId` participates in the
+    // domain construction.
+    let cfg = ChannelConfig {
+        payer: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+            .parse()
+            .unwrap(),
+        payer_authorizer: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+            .parse()
+            .unwrap(),
+        receiver: "0x19ee5100D3a1e687F85B952bd3FbEc108Ab6A8d7"
+            .parse()
+            .unwrap(),
+        receiver_authorizer: "0xd407e409E34E0b9afb99EcCeb609bDbcD5e7f1bf"
+            .parse()
+            .unwrap(),
+        token: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+            .parse()
+            .unwrap(),
+        withdraw_delay: 900,
+        salt: B256::ZERO,
+    };
+    assert_eq!(
+        compute_channel_id(&cfg, 1),
+        b256!("0x511b6617e235c4e0c4837f7b51700a3b324110c88225aee727a74536cce36192"),
+    );
+}
+
+#[test]
+fn voucher_digest_at_u128_max_matches_viem_reference_vector() {
+    // Boundary case: `max_claimable_amount` at `U128::MAX` for the
+    // channel id pinned above. Pins the `uint128` encoding edge —
+    // any off-by-one in the U128 abi encoding would change the
+    // resulting digest.
+    let channel_id = b256!("0x5fafb915f0dbee350d7f84d91802dea47e8e3a71929c3cd79da161c291fb28bd");
+    assert_eq!(
+        compute_voucher_digest(channel_id, U128::MAX, BASE_SEPOLIA_CHAIN_ID),
+        b256!("0x9d774906d7e4dbe91d887f3845e83c17c8fed29ca225d14d809d75bea7c3e547"),
+    );
+}
+
+#[test]
+fn voucher_digest_at_zero_amount_matches_viem_reference_vector() {
+    // Boundary case: `max_claimable_amount = 0` for the channel id
+    // pinned above. Catches an implementation that special-cases the
+    // zero value or that drops the field on serialization.
+    let channel_id = b256!("0x5fafb915f0dbee350d7f84d91802dea47e8e3a71929c3cd79da161c291fb28bd");
+    assert_eq!(
+        compute_voucher_digest(channel_id, U128::ZERO, BASE_SEPOLIA_CHAIN_ID),
+        b256!("0x4187c22619aeed9d5381a1d0c37c9e936e6dfe666f963f7ccfd524e3b8f55173"),
+    );
+}
+
+#[test]
+fn voucher_signature_recovers_to_payer_for_viem_reference_vector() {
+    // The signature was produced by viem over VIEM_VOUCHER_DIGEST. Recovering
+    // it with `alloy_primitives` against the digest that `compute_voucher_digest`
+    // produces must yield VIEM_PAYER. This pins the whole client→facilitator
+    // signature path: viem signing, alloy's typed-data digest, and alloy's
+    // ECDSA recovery all agree, so a real client-produced voucher verifies
+    // against this facilitator.
+    let digest = compute_voucher_digest(
+        VIEM_CHANNEL_ID,
+        U128::from(VIEM_MAX_CLAIMABLE),
+        BASE_SEPOLIA_CHAIN_ID,
+    );
+    assert_eq!(digest, VIEM_VOUCHER_DIGEST);
+
+    let sig_bytes = hex::decode(VIEM_SIGNATURE).unwrap();
+    let sig = Signature::from_raw(&sig_bytes).unwrap();
+    let recovered = sig.recover_address_from_prehash(&digest).unwrap();
+
+    assert_eq!(recovered, VIEM_PAYER.parse::<Address>().unwrap());
+}
+
+#[test]
+fn verify_voucher_end_to_end_for_viem_reference_vector() {
+    // End-to-end of the voucher crypto core, anchored to viem: recompute the
+    // channel id from the wire `ChannelConfig`, recompute the voucher digest,
+    // recover the signer from the viem signature, and confirm it matches the
+    // channel's declared `payer_authorizer`. This is exactly the chain
+    // `verify` runs before consulting on-chain state, with every intermediate
+    // value pinned to a byte-exact viem reference.
+    let cfg = viem_channel_config();
+
+    let channel_id = compute_channel_id(&cfg, BASE_SEPOLIA_CHAIN_ID);
+    assert_eq!(channel_id, VIEM_CHANNEL_ID);
+
+    let digest = compute_voucher_digest(
+        channel_id,
+        U128::from(VIEM_MAX_CLAIMABLE),
+        BASE_SEPOLIA_CHAIN_ID,
+    );
+    assert_eq!(digest, VIEM_VOUCHER_DIGEST);
+
+    let sig = Signature::from_raw(&hex::decode(VIEM_SIGNATURE).unwrap()).unwrap();
+    let recovered = sig.recover_address_from_prehash(&digest).unwrap();
+
+    // The recovered voucher signer must be the channel's payer authorizer.
+    assert_eq!(recovered, cfg.payer_authorizer.0);
+}
+
+#[test]
+fn claim_payload_serializes_to_canonical_wire_shape() {
+    // The existing `claim_payload_round_trips` test only checks `type` and
+    // serde round-trip equality, which does not catch a `rename`/`rename_all`
+    // drift on the nested fields. Pin the canonical camelCase wire field names
+    // the facilitator's `POST /settle` consumes for a `type: "claim"` payload.
+    let payload = BatchSettlementPayload::Claim(ClaimPayload {
+        claims: vec![VoucherClaim {
+            voucher: VoucherClaimVoucher {
+                channel: viem_channel_config(),
+                max_claimable_amount: U128::from(5_000u128).into(),
+            },
+            signature: hex::decode(VIEM_SIGNATURE).unwrap().into(),
+            total_claimed: U128::from(5_000u128).into(),
+        }],
+        claim_authorizer_signature: None,
+    });
+    let json = serde_json::to_value(&payload).unwrap();
+
+    assert_eq!(json["type"], "claim");
+    let claim = &json["claims"][0];
+    assert_eq!(claim["voucher"]["maxClaimableAmount"], "5000");
+    assert_eq!(claim["voucher"]["channel"]["payer"], VIEM_PAYER);
+    assert_eq!(claim["voucher"]["channel"]["payerAuthorizer"], VIEM_PAYER);
+    assert_eq!(
+        claim["voucher"]["channel"]["receiverAuthorizer"],
+        VIEM_RECEIVER_AUTHORIZER
+    );
+    assert_eq!(claim["voucher"]["channel"]["withdrawDelay"], 900);
+    assert_eq!(claim["totalClaimed"], "5000");
+    // Server-delegated authorizer: the optional signature is omitted, not null.
+    assert!(json.get("claimAuthorizerSignature").is_none());
+}
+
+#[test]
+fn settle_payload_serializes_to_canonical_wire_shape() {
+    // Pin the canonical wire field names for a `type: "settle"` payload.
+    let payload = BatchSettlementPayload::Settle(SettlePayload {
+        receiver: VIEM_RECEIVER.parse().unwrap(),
+        token: VIEM_TOKEN.parse().unwrap(),
+    });
+    let json = serde_json::to_value(&payload).unwrap();
+
+    assert_eq!(json["type"], "settle");
+    assert_eq!(json["receiver"], VIEM_RECEIVER);
+    assert_eq!(json["token"], VIEM_TOKEN);
+}
+
+#[test]
 fn payment_requirements_extra_serializes_channel_state_when_present() {
     let req = sample_requirements(
         "0x0000000000000000000000000000000000000003",
@@ -249,4 +468,63 @@ fn receiver_authorizer_signs_and_recovers_for_voucher_digest() {
         .recover_address_from_prehash(&voucher_digest)
         .unwrap();
     assert_eq!(recovered, voucher_signer_address);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-implementation EIP-712 golden vectors (viem <-> alloy <-> hand-rolled).
+//
+// Contributed by @Adelagric (issue #92, Adelagric/x402-batch-settlement): the
+// canonical vectors the official x402 client SDK signs with (viem
+// `hashTypedData`), independently reproduced by a hand-rolled
+// keccak256 + abi.encode implementation. They pin `alloy_sol_types`' typed-data
+// hashing byte-for-byte against viem — a one-byte drift in any type string, the
+// domain, or the struct encoding changes one of these hashes and fails here,
+// instead of silently rejecting real client signatures at the facilitator. The
+// two assertions transitively pin the typehashes too.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn channel_id_matches_viem_reference_vector() {
+    // Vector generated with viem `hashTypedData` over the canonical
+    // `x402 Batch Settlement` EIP-712 domain on Base Sepolia (chainId 84532).
+    // Independently reproduced by a hand-rolled keccak256+abi.encode
+    // implementation; both equal the constant below — so the assertion pins
+    // `alloy_sol_types` against viem.
+    let cfg = ChannelConfig {
+        payer: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+            .parse()
+            .unwrap(),
+        payer_authorizer: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+            .parse()
+            .unwrap(),
+        receiver: "0x19ee5100D3a1e687F85B952bd3FbEc108Ab6A8d7"
+            .parse()
+            .unwrap(),
+        receiver_authorizer: "0xd407e409E34E0b9afb99EcCeb609bDbcD5e7f1bf"
+            .parse()
+            .unwrap(),
+        token: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+            .parse()
+            .unwrap(),
+        withdraw_delay: 900,
+        salt: B256::ZERO,
+    };
+    assert_eq!(
+        compute_channel_id(&cfg, BASE_SEPOLIA_CHAIN_ID),
+        b256!("0x5fafb915f0dbee350d7f84d91802dea47e8e3a71929c3cd79da161c291fb28bd"),
+    );
+}
+
+#[test]
+fn voucher_digest_matches_viem_reference_vector() {
+    // Same vector source: viem `hashTypedData` over
+    // `Voucher(bytes32 channelId,uint128 maxClaimableAmount)` under the
+    // `x402 Batch Settlement` domain on Base Sepolia. channel_id is the one
+    // pinned by `channel_id_matches_viem_reference_vector`;
+    // max_claimable_amount = 1000.
+    let channel_id = b256!("0x5fafb915f0dbee350d7f84d91802dea47e8e3a71929c3cd79da161c291fb28bd");
+    assert_eq!(
+        compute_voucher_digest(channel_id, U128::from(1_000u128), BASE_SEPOLIA_CHAIN_ID),
+        b256!("0xa2874adbecca0abb1884b4ac1c100e3906d25208ad0c9e6a8fcf9790ccfa2246"),
+    );
 }

--- a/facilitator/src/run.rs
+++ b/facilitator/src/run.rs
@@ -43,7 +43,7 @@ use x402_types::scheme::{SchemeBlueprints, SchemeRegistry};
 #[cfg(feature = "chain-aptos")]
 use x402_chain_aptos::V2AptosExact;
 #[cfg(feature = "chain-eip155")]
-use x402_chain_eip155::{V1Eip155Exact, V2Eip155Exact, V2Eip155Upto};
+use x402_chain_eip155::{V1Eip155Exact, V2Eip155BatchSettlement, V2Eip155Exact, V2Eip155Upto};
 #[cfg(feature = "chain-solana")]
 use x402_chain_solana::{V1SolanaExact, V2SolanaExact};
 #[cfg(feature = "chain-tron")]
@@ -88,6 +88,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
             scheme_blueprints.register(V1Eip155Exact);
             scheme_blueprints.register(V2Eip155Exact);
             scheme_blueprints.register(V2Eip155Upto);
+            scheme_blueprints.register(V2Eip155BatchSettlement);
         }
         #[cfg(feature = "chain-solana")]
         {

--- a/facilitator/src/schemes.rs
+++ b/facilitator/src/schemes.rs
@@ -39,7 +39,7 @@ use x402_types::scheme::{X402SchemeFacilitator, X402SchemeFacilitatorBuilder};
 #[cfg(feature = "chain-aptos")]
 use x402_chain_aptos::V2AptosExact;
 #[cfg(feature = "chain-eip155")]
-use x402_chain_eip155::{V1Eip155Exact, V2Eip155Exact, V2Eip155Upto};
+use x402_chain_eip155::{V1Eip155Exact, V2Eip155BatchSettlement, V2Eip155Exact, V2Eip155Upto};
 #[cfg(feature = "chain-solana")]
 use x402_chain_solana::{V1SolanaExact, V2SolanaExact};
 #[cfg(feature = "chain-tron")]
@@ -159,6 +159,25 @@ impl X402SchemeFacilitatorBuilder<&ChainProvider> for V1Eip155Exact {
             Arc::clone(provider)
         } else {
             return Err("V1Eip155Exact::build: provider must be an Eip155ChainProvider".into());
+        };
+        self.build(eip155_provider, config)
+    }
+}
+
+#[cfg(feature = "chain-eip155")]
+impl X402SchemeFacilitatorBuilder<&ChainProvider> for V2Eip155BatchSettlement {
+    fn build(
+        &self,
+        provider: &ChainProvider,
+        config: Option<serde_json::Value>,
+    ) -> Result<Box<dyn X402SchemeFacilitator>, Box<dyn std::error::Error>> {
+        #[allow(irrefutable_let_patterns)] // For when just chain-aptos is enabled
+        let eip155_provider = if let ChainProvider::Eip155(provider) = provider {
+            Arc::clone(provider)
+        } else {
+            return Err(
+                "V2Eip155BatchSettlement::build: provider must be an Eip155ChainProvider".into(),
+            );
         };
         self.build(eip155_provider, config)
     }


### PR DESCRIPTION
## Summary

Adds the EIP-155 batch-settlement facilitator implementation for x402-rs.

This implements Rust facilitator-side support for the `batch-settlement` scheme, covering verification and settlement flows described by the x402 batch-settlement docs and the Go facilitator reference.

References:

- https://docs.x402.org/schemes/batch-settlement
- https://www.x402.org/writing/x402-batch-settlement
- https://github.com/x402-foundation/x402/tree/main/examples/go/facilitator/batch-settlement

## Implementation

The facilitator now supports:

- Deposit verification and settlement for ERC-3009 deposits.
- Deposit verification and settlement for canonical Permit2 prior-allowance deposits.
- Voucher verification against channel state, including ECDSA and EIP-1271 signature paths.
- Claim settlement with receiver-authorizer signatures.
- Receiver settlement through `settle(receiver, token)`.
- Client refund verification and enriched refund settlement.
- Channel state extras for verify, settle, and corrective responses.
- Batch-settlement error codes and response serialization.

## Verification Behavior

- Deposit `/verify` rejects malformed zero or uint128-overflow deposit amounts.
- Deposit `/verify` validates the deposit authorization, voucher, channel config, channel state, payer balance, and simulates the deposit call.
- Deposit `/verify` returns projected post-deposit channel state, matching the Go reference.
- Voucher and refund verification return corrective channel/voucher state where applicable.
- Enriched refund payloads are rejected on `/verify`; client refund payloads are accepted.

## Settlement Behavior

- Deposit `/settle` submits the deposit transaction and returns channel state that is resilient to stale RPC reads.
- Claim `/settle` simulates before submitting claim transactions.
- Receiver `settle(receiver, token)` validates receiver/token, simulates, submits the settlement transaction, and reports the settled event amount when present.
- Refund `/settle` checks channel nonce/state, simulates direct refund or refund+claim multicall, reports actual refund, and allows other-channel claims in the multicall while only counting same-channel claims for refund availability.

## Security / Correctness Notes

- ERC-3009 and Permit2 signatures are verified during `/verify` before settlement.
- Permit2 support binds owner, spender, token, amount, witness, deadline, and prior allowance.
- Integer narrowing from `uint256` to `uint128` is checked before ABI calls.
- Refund nonce and channel state are checked before submitting refund settlement.

## Testing

- `cargo test -p x402-chain-eip155 --features facilitator`
- `cargo fmt --check`
- `git diff --check`
