### PR TITLE
feat(eip155): add Radius Network and Radius Testnet with SBC default stablecoin

### DIFF
--- a/crates/chains/x402-chain-eip155/README.md
+++ b/crates/chains/x402-chain-eip155/README.md
@@ -99,8 +99,9 @@ The crate includes built-in support for many EVM networks through the `KnownNetw
 - **Peaq**
 - **IoTeX**
 - **Celo** (mainnet and Sepolia testnet)
+- **Radius** (mainnet and testnet)
 
-Each network includes USDC token deployment information with proper EIP-712 domain parameters.
+Known token deployment helpers include USDC on supported USDC networks and SBC on Radius networks.
 
 ## ERC-3009 and Signature Handling
 

--- a/crates/chains/x402-chain-eip155/src/networks.rs
+++ b/crates/chains/x402-chain-eip155/src/networks.rs
@@ -1,5 +1,5 @@
 use x402_types::chain::ChainId;
-use x402_types::networks::USDC;
+use x402_types::networks::{SBC, USDC};
 
 use crate::chain::{AssetTransferMethod, Eip155ChainReference, Eip155TokenDeployment};
 
@@ -75,6 +75,16 @@ pub trait KnownNetworkEip155<A> {
 
     /// Returns the instance for Celo testnet (eip155:11142220)
     fn celo_sepolia() -> A;
+}
+
+/// Trait providing SBC deployments on EIP-155 networks where SBC is a known payment asset.
+#[allow(dead_code)]
+pub trait KnownSbcEip155 {
+    /// Returns the SBC deployment for Radius Network (eip155:723487).
+    fn radius() -> Eip155TokenDeployment;
+
+    /// Returns the SBC deployment for Radius Testnet (eip155:72344).
+    fn radius_testnet() -> Eip155TokenDeployment;
 }
 
 /// Implementation of KnownNetworkEip155 for ChainId.
@@ -308,5 +318,51 @@ impl KnownNetworkEip155<Eip155TokenDeployment> for USDC {
                 version: "2".into(),
             },
         }
+    }
+}
+
+impl KnownSbcEip155 for SBC {
+    fn radius() -> Eip155TokenDeployment {
+        Eip155TokenDeployment {
+            chain_reference: Eip155ChainReference::new(723487),
+            address: alloy_primitives::address!("0x33ad9e4BD16B69B5BFdED37D8B5D9fF9aba014Fb"),
+            decimals: 6,
+            transfer_method: AssetTransferMethod::Permit2,
+        }
+    }
+
+    fn radius_testnet() -> Eip155TokenDeployment {
+        Eip155TokenDeployment {
+            chain_reference: Eip155ChainReference::new(72344),
+            address: alloy_primitives::address!("0x33ad9e4BD16B69B5BFdED37D8B5D9fF9aba014Fb"),
+            decimals: 6,
+            transfer_method: AssetTransferMethod::Permit2,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sbc_radius_deployments_use_permit2() {
+        let radius = SBC::radius();
+        assert_eq!(radius.chain_reference.inner(), 723487);
+        assert_eq!(
+            radius.address,
+            alloy_primitives::address!("0x33ad9e4BD16B69B5BFdED37D8B5D9fF9aba014Fb")
+        );
+        assert_eq!(radius.decimals, 6);
+        assert_eq!(radius.transfer_method, AssetTransferMethod::Permit2);
+
+        let radius_testnet = SBC::radius_testnet();
+        assert_eq!(radius_testnet.chain_reference.inner(), 72344);
+        assert_eq!(
+            radius_testnet.address,
+            alloy_primitives::address!("0x33ad9e4BD16B69B5BFdED37D8B5D9fF9aba014Fb")
+        );
+        assert_eq!(radius_testnet.decimals, 6);
+        assert_eq!(radius_testnet.transfer_method, AssetTransferMethod::Permit2);
     }
 }

--- a/crates/x402-types/src/networks.rs
+++ b/crates/x402-types/src/networks.rs
@@ -33,8 +33,9 @@
 //! - **Chain-Specific Traits**: Chain-specific crates (e.g., `x402-chain-eip155`, `x402-chain-solana`)
 //!   implement namespace-specific traits like [`KnownNetworkEip155`] and [`KnownNetworkSolana`]
 //!   for type-safe network access
-//! - **Token Deployments**: The [`USDC`] marker struct is used by chain-specific crates to provide
-//!   per-network token deployment information (e.g., USDC addresses on different chains)
+//! - **Token Deployments**: The [`USDC`] and [`SBC`] marker structs are used by chain-specific
+//!   crates to provide per-network token deployment information (e.g., token addresses on
+//!   different chains)
 //!
 //! # CAIP-2 Standard
 //!
@@ -53,11 +54,11 @@
 //! - [`KNOWN_NETWORKS`]: A static array of all well-known networks
 //! - [`chain_id_by_network_name`]: Lookup function to get ChainId by network name
 //! - [`network_name_by_chain_id`]: Reverse lookup function to get network name by ChainId
-//! - [`USDC`]: Marker struct used for token deployment implementations
+//! - [`USDC`] and [`SBC`]: Marker structs used for token deployment implementations
 //!
 //! # Namespace-Specific Traits
 //!
-//! The module provides two namespace-specific traits for better organization and flexibility:
+//! The module provides namespace-specific traits for better organization and flexibility:
 //!
 //! ## KnownNetworkEip155
 //! Provides convenient static methods for all EVM networks (eip155 namespace):
@@ -67,6 +68,7 @@
 //! - Sei, Sei Testnet
 //! - XDC, XRPL EVM, Peaq, IoTeX
 //! - Celo, Celo Sepolia
+//! - Radius, Radius Testnet
 //!
 //! ## KnownNetworkSolana
 //! Provides convenient static methods for Solana networks:
@@ -75,8 +77,8 @@
 //!
 //! # Supported Networks
 //!
-//! The module supports 16 blockchain networks across two namespaces:
-//! - **EVM Networks (14)**: All networks in the eip155 namespace
+//! The module supports 18 blockchain networks across two namespaces:
+//! - **EVM Networks (16)**: All networks in the eip155 namespace
 //! - **Solana Networks (2)**: Solana mainnet and devnet
 //!
 //! # Examples
@@ -226,6 +228,17 @@ pub static KNOWN_NETWORKS: &[NetworkInfo] = &[
         name: "celo-sepolia",
         namespace: "eip155",
         reference: "11142220",
+    },
+    // Radius Networks
+    NetworkInfo {
+        name: "radius",
+        namespace: "eip155",
+        reference: "723487",
+    },
+    NetworkInfo {
+        name: "radius-testnet",
+        namespace: "eip155",
+        reference: "72344",
     },
     // Solana Networks
     NetworkInfo {
@@ -418,6 +431,13 @@ pub fn network_name_by_chain_id(chain_id: &ChainId) -> Option<&'static str> {
 #[allow(dead_code, clippy::upper_case_acronyms)] // Public for consumption by downstream crates.
 pub struct USDC;
 
+/// Marker struct for SBC token deployment implementations.
+///
+/// Chain-specific crates implement traits for this marker struct to provide
+/// per-network SBC token deployment information.
+#[allow(dead_code, clippy::upper_case_acronyms)] // Public for consumption by downstream crates.
+pub struct SBC;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -440,6 +460,14 @@ mod tests {
         assert_eq!(celo.namespace, "eip155");
         assert_eq!(celo.reference, "42220");
 
+        let radius = chain_id_by_network_name("radius").unwrap();
+        assert_eq!(radius.namespace, "eip155");
+        assert_eq!(radius.reference, "723487");
+
+        let radius_testnet = chain_id_by_network_name("radius-testnet").unwrap();
+        assert_eq!(radius_testnet.namespace, "eip155");
+        assert_eq!(radius_testnet.reference, "72344");
+
         let solana = chain_id_by_network_name("solana").unwrap();
         assert_eq!(solana.namespace, "solana");
         assert_eq!(solana.reference, "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp");
@@ -461,6 +489,14 @@ mod tests {
         let network_name = network_name_by_chain_id(&celo_sepolia_chain_id).unwrap();
         assert_eq!(network_name, "celo-sepolia");
 
+        let radius_chain_id = ChainId::new("eip155", "723487");
+        let network_name = network_name_by_chain_id(&radius_chain_id).unwrap();
+        assert_eq!(network_name, "radius");
+
+        let radius_testnet_chain_id = ChainId::new("eip155", "72344");
+        let network_name = network_name_by_chain_id(&radius_testnet_chain_id).unwrap();
+        assert_eq!(network_name, "radius-testnet");
+
         let solana_chain_id = ChainId::new("solana", "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp");
         let network_name = network_name_by_chain_id(&solana_chain_id).unwrap();
         assert_eq!(network_name, "solana");
@@ -476,6 +512,9 @@ mod tests {
 
         let celo_chain_id = ChainId::new("eip155", "42220");
         assert_eq!(celo_chain_id.as_network_name(), Some("celo"));
+
+        let radius_chain_id = ChainId::new("eip155", "723487");
+        assert_eq!(radius_chain_id.as_network_name(), Some("radius"));
 
         let solana_chain_id = ChainId::new("solana", "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp");
         assert_eq!(solana_chain_id.as_network_name(), Some("solana"));


### PR DESCRIPTION
## Overview

This change adds first-class support for Radius Network (mainnet, chain ID `723487`) and Radius Testnet (chain ID `72344`) to the Rust x402 stack, mirroring the equivalent TypeScript additions merged upstream in [x402-foundation/x402#2038](https://github.com/x402-foundation/x402/pull/2038). Radius is an EVM-compatible, stablecoin-native network whose default payment asset is SBC (a permit-enabled USD stablecoin issued via Brale). Because SBC ships with EIP-2612 permit support and Radius deploys the canonical Permit2 contract, both Radius deployments register with `AssetTransferMethod::Permit2`.

## Summary of changes

- `crates/x402-types/src/networks.rs`: added `radius` and `radius-testnet` entries to `KNOWN_NETWORKS`, introduced a new `SBC` marker struct alongside the existing `USDC` marker, updated module docs (total networks 16 → 18; EVM networks 14 → 16), and extended the lookup tests in both directions.
- `crates/chains/x402-chain-eip155/src/networks.rs`: added a `KnownSbcEip155` trait with `radius()` and `radius_testnet()` deployment constructors, implemented it for `SBC` using the canonical SBC token address, 6 decimals, and `AssetTransferMethod::Permit2`, and added a `sbc_radius_deployments_use_permit2` unit test asserting all fields.
- `crates/chains/x402-chain-eip155/README.md`: documented Radius (mainnet and testnet) in the supported networks list and noted that known token helpers now cover SBC on Radius in addition to USDC elsewhere.

## Network details

| Field | Radius Network (mainnet) | Radius Testnet |
|---|---|---|
| CAIP-2 chain ID | `eip155:723487` | `eip155:72344` |
| Network name | `radius` | `radius-testnet` |
| Default stablecoin | SBC | SBC |
| SBC token address | `0x33ad9e4BD16B69B5BFdED37D8B5D9fF9aba014Fb` | `0x33ad9e4BD16B69B5BFdED37D8B5D9fF9aba014Fb` |
| Decimals | 6 | 6 |
| Transfer method | Permit2 (EIP-2612 permit + Permit2) | Permit2 (EIP-2612 permit + Permit2) |
| Permit2 address | `0x000000000022D473030F116dDEE9F6B43aC78BA3` | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
| RPC URL | `https://rpc.radiustech.xyz` | `https://rpc.testnet.radiustech.xyz` |
| Explorer | `https://network.radiustech.xyz` | `https://testnet.radiustech.xyz` |

## References

- Upstream TypeScript counterpart (merged 2026-05-07): https://github.com/x402-foundation/x402/pull/2038
- Radius x402 facilitator API docs: https://docs.radiustech.xyz/developer-resources/x402-facilitator-api