### PR TITLE
docs: add TWZRD Agent Intel to Related Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ For full facilitator configuration and deployment details, see the [`x402-facili
 * [x402 Protocol Documentation](https://x402.org)
 * [x402 Overview by Coinbase](https://docs.cdp.coinbase.com/x402/docs/overview)
 * [Facilitator Documentation by Coinbase](https://docs.cdp.coinbase.com/x402/docs/facilitator)
+* [TWZRD Agent Intel](https://intel.twzrd.xyz) — Live x402 MCP server on Solana. Trust-score agent wallets before USDC micropayments; returns cryptographically signed Ed25519 trust receipts. Free tools + paid `get_trust_receipt` (HTTP 402). MCP endpoint: `https://intel.twzrd.xyz/mcp`
 
 ## Contributions and Feedback
 
@@ -146,3 +147,4 @@ Feel free to open issues or pull requests to improve x402 support in the Rust ec
 ## License
 
 [Apache-2.0](LICENSE)
+


### PR DESCRIPTION
## What

Adds **TWZRD Agent Intel** to the Related Resources section.

## Why it fits

TWZRD Agent Intel is a live production x402 server running on Solana — directly relevant to anyone using x402-rs to build Rust-based clients or facilitators:

- **For client builders**: TWZRD is a real x402 endpoint your Rust `x402-reqwest` client can call. The `get_trust_receipt` tool responds with an HTTP 402 challenge, accepts USDC on Solana mainnet, and returns a signed trust receipt — a concrete end-to-end test target for x402 flow.
- **Free tools**: `score_agent(wallet)`, `preflight_check(wallet)` — no payment required
- **Paid tool**: `get_trust_receipt(wallet)` — HTTP 402 + USDC micropayment on Solana mainnet
- **MCP server**: `https://intel.twzrd.xyz/mcp` (streamable-http)

Useful as a reference implementation of x402 in a real production service with Solana support (which x402-rs also supports per the roadmap).